### PR TITLE
🌱 chore: eslint switch-case indent 규칙 추가

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
   "extends": ["react-app", "prettier"],
   "rules": {
-    "indent": ["error", 2],
+    "indent": ["error", 2, { "SwitchCase": 1 }],
     "no-var": "error",
     "require-await": "error",
     "eqeqeq": "warn",


### PR DESCRIPTION
- [ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [ ] 🧹 불필요한 코드는 제거했나요?
- [ ] 💭 이슈는 등록했나요?
- [ ] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
eslint switch-case indent 규칙 추가

<br><br>

## 💬 참고 사항
현재 방꾸석 프로젝트에는 들여쓰기 2칸을 사용하고 있다.
SwitchCase가 1로 설정된 상태는 switch 문과 관련하여 case 절을 2칸 들여쓰기한다.
해당 규칙을 추가하지 않을 시 eslint에서 indent 에러가 발생한다.

<img width="463" alt="image" src="https://github.com/FRONTENDSCHOOL5/final-14-BangKKuseok/assets/51310674/e2e9a78b-65b4-4cd8-a3fc-08239fa00f02">

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #37

<br><br>
