### PR TITLE
♻️ refactor: ViewTabs 마크업 구조 변경 및 props 수정

### DIFF
--- a/src/components/common/Tabs/ViewTabs.jsx
+++ b/src/components/common/Tabs/ViewTabs.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
-import listImg from '../../../assets/icons/icon-list.svg'
-import listActiveImg from '../../../assets/icons/icon-list-active.svg'
-import gridImg from '../../../assets/icons/icon-gallery.svg'
-import gridActiveImg from '../../../assets/icons/icon-gallery-active.svg'
+import listImg from '../../../assets/icons/icon-list.svg';
+import listActiveImg from '../../../assets/icons/icon-list-active.svg';
+import gridImg from '../../../assets/icons/icon-gallery.svg';
+import gridActiveImg from '../../../assets/icons/icon-gallery-active.svg';
 
 const StyledViewTabs = styled.nav`
   margin: 0 16px 20px 0;
@@ -11,21 +11,23 @@ const StyledViewTabs = styled.nav`
   justify-content: flex-end;
   gap: 10px;
 
-  button{
+  button {
     width: 4rem;
     padding: unset;
   }
 `;
 
-export default function ViewTabs({selected, ...rest}) {
-  return <StyledViewTabs {...rest}>
-    <button type='button' id='grid' >
-      <img src={selected === 'grid' ? gridActiveImg : gridImg} alt='그리드형 버튼' />
-    </button>
-    <button type='button' id ='list'>
-      <img src={selected === 'list' ? listActiveImg : listImg} alt='리스트형 버튼' />
-    </button>
-  </StyledViewTabs>;
+export default function ViewTabs({ selectedTab, onClick }) {
+  return (
+    <StyledViewTabs>
+      <button type='button' aria-label='리스트형 버튼' onClick={() => onClick('list')}>
+        <img src={selectedTab === 'list' ? listActiveImg : listImg} alt='리스트형 버튼' />
+      </button>
+      <button type='button' aria-label='리스트형 버튼' onClick={() => onClick('grid')}>
+        <img src={selectedTab === 'grid' ? gridActiveImg : gridImg} alt='그리드형 버튼' />
+      </button>
+    </StyledViewTabs>
+  );
 }
 
 // 기능 구현법


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
ViewTabs의 마크업 구조를 변경하고 props를 수정하였다.

<br><br>

## 🔍 상세 작업 내용
- prettier 미적용된 부분 적용
- 그리드형/리스트형 구조 -> 리스트형/그리드형 구조로 마크업 변경
- 선택된 탭에 따라 활성화 되게끔 onClick props 추가

<br><br>

## 💬 참고 사항
- ViewTabs 컴포넌트 사용방법
```jsx
<ViewTabs selectedTab={selectedTab} onClick={} />
```

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #40

<br><br>
