### PR TITLE
🎨 style: 공통 Modal UI 컴포넌트 구현

### DIFF
--- a/src/components/common/BottomSheet/BasicModal.jsx
+++ b/src/components/common/BottomSheet/BasicModal.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const BasicModalWrapper = styled.div`
+  height: 192px;
+  margin: 0 16px;
+`;
+
+export default function BasicModal({ children }) {
+  return <BasicModalWrapper>{children}</BasicModalWrapper>;
+}

--- a/src/components/common/BottomSheet/BottomSheet.jsx
+++ b/src/components/common/BottomSheet/BottomSheet.jsx
@@ -1,0 +1,51 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { BottomSheetDim, ModalBox, HeaderModal } from './BottomSheetStyle';
+import ListModal from './ListModal';
+import BasicModal from './BasicModal';
+
+// type: basic, list
+function BottomSheet({ type = 'basic', isShow, setIsShow, children }) {
+  const [animate, setAnimate] = useState(false);
+  const [localVisible, setLocalVisible] = useState(isShow);
+  const wrapperRef = useRef(null);
+  const modalBoxRef = useRef(null);
+
+  useEffect(() => {
+    setLocalVisible(isShow);
+  }, [isShow]);
+
+  useEffect(() => {
+    if (localVisible && !isShow) {
+      setAnimate(true);
+      setTimeout(() => setAnimate(false), 250);
+    } // 0.25초뒤에 없어짐
+    setLocalVisible(isShow);
+  }, [localVisible, isShow]);
+
+  // Dim 클릭했을 때, ModalBox부분을 제외한 영역이어야 동작하도록
+  const handleDimClick = (e) => {
+    if (wrapperRef.current && modalBoxRef.current && !modalBoxRef.current.contains(e.target)) {
+      setIsShow(false);
+    }
+  };
+
+  // ModalBox의 HeaderModal을 클릭했을 때 동작
+  const handleHeaderModalClick = () => {
+    setIsShow(false);
+  };
+
+  if (!localVisible && !animate) return null;
+
+  return (
+    <>
+      <BottomSheetDim onClick={handleDimClick} disappear={!isShow} ref={wrapperRef}>
+        <ModalBox disappear={!isShow} ref={modalBoxRef}>
+          <HeaderModal onClick={handleHeaderModalClick} />
+          {type === 'list' ? <ListModal /> : <BasicModal>{children}</BasicModal>}
+        </ModalBox>
+      </BottomSheetDim>
+    </>
+  );
+}
+
+export default BottomSheet;

--- a/src/components/common/BottomSheet/BottomSheetStyle.jsx
+++ b/src/components/common/BottomSheet/BottomSheetStyle.jsx
@@ -1,0 +1,103 @@
+import styled, { css, keyframes } from 'styled-components';
+
+const fadeIn = keyframes`
+from {
+    opacity: 0;
+}
+to {
+    opacity: 1;
+}
+`;
+const fadeOut = keyframes`
+from {
+    opacity: 1;
+}
+to {
+    opacity: 0;
+}
+`;
+
+const slideUp = keyframes`
+  from {
+    transform: translateY(100%);
+  }
+
+  to {
+    transform: translateY(calc(100% - ${({ LEN }) => (LEN < 425 ? LEN : 425)}px));
+  }
+`;
+
+const slideDown = keyframes`
+  from {
+    transform: translateY(calc(100% - ${({ LEN }) => (LEN < 425 ? LEN : 425)}px));
+  }
+
+  to {
+    transform: translateY(100%);
+  }
+`;
+
+export const BottomSheetDim = styled.div`
+  position: absolute;
+  top: 0;
+
+  width: 100%;
+  height: 100vh;
+
+  background-color: rgba(0, 0, 0, 0.3);
+  transition: background-color 0.25s ease-out;
+
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  animation: ${fadeIn} 0.25s ease-out forwards;
+
+  ${(props) =>
+    props.disappear &&
+    css`
+      animation-name: ${fadeOut};
+    `}
+`;
+
+export const ModalBox = styled.div`
+  width: inherit;
+  height: ${({ LEN }) => (LEN < 425 ? LEN : 425)}px;
+  border-radius: 1rem 1rem 0 0;
+
+  position: absolute;
+  bottom: 0;
+
+  display: flex;
+  flex-direction: column;
+
+  background-color: ${({ theme }) => theme.colors.white};
+  animation: ${slideUp} 0.25s ease-out forwards;
+
+  ${(props) =>
+    props.disappear &&
+    css`
+      animation-name: ${slideDown};
+      animation-timing-function: ease-in;
+    `}
+`;
+
+export const HeaderModal = styled.button`
+  width: 100%;
+  height: 48px;
+
+  position: relative;
+
+  &::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+
+    width: 50px;
+    height: 4px;
+
+    background-color: ${({ theme }) => theme.colors.gray100};
+  }
+`;

--- a/src/components/common/BottomSheet/ListModal.jsx
+++ b/src/components/common/BottomSheet/ListModal.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const BottomSheetListWrapper = styled.ul`
+  max-height: 425px;
+  overflow-y: scroll;
+  ::-webkit-scrollbar {
+    width: 0;
+    background: transparent;
+  }
+`;
+
+const ListItem = styled.li`
+  height: 48px;
+  display: flex;
+  align-items: center;
+  padding: 0 24px;
+  font-size: ${({ theme }) => theme.fontSize.sm};
+`;
+
+const LEN = 0;
+
+export default function ListModal({ items }) {
+  const LEN = items.length * 48;
+
+  return (
+    <BottomSheetListWrapper>
+      {items.map((item, index) => (
+        <ListItem key={index}>{item}</ListItem>
+      ))}
+    </BottomSheetListWrapper>
+  );
+}
+
+export { LEN };

--- a/src/components/common/Modal/Modal.jsx
+++ b/src/components/common/Modal/Modal.jsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function Modal() {
-  return <div>Modal</div>;
-}


### PR DESCRIPTION
기본 BottomSheet틀을 만들고, 경우에 따라 BasicModal, ListModal을 받아오도록 하였다.

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
공통 Modal UI 컴포넌트 구현

<br><br>

## 🔍 상세 작업 내용
기본 BottomSheet파일을 만들고 상황에 따라 BasicModal 또는 ListModal을 불러오게 했다.
기본 BottomSheet의 경우, 바깥의 버튼을 누르면 ModalBox가 올라오도록 하고, Dim 부분 혹은 모달의 헤더(HeaderModal)을 누르면 내려가도록 구현했다.
ListModal의 경우, 리스트를 받아올 때 총 height가 425px이 넘어가면 스크롤으로 리스트를 보여지게 구현하였다(스크롤은 보이지 않게 숨겼음)

<br><br>

## 💬 참고 사항
`const [isShow, setIsShow] = useState(false);

const handleClickButton = () => {
setIsShow(true);
};

return (
<>
<BottomSheet type='' isShow={isShow} setIsShow={setIsShow}></BottomSheet>
</>
);`

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #19 

<br><br>
