### PR TITLE
✨ feat: 홈페이지 마크업 및 기능 구현

### DIFF
--- a/src/components/common/Carousel/CarouselStyle.jsx
+++ b/src/components/common/Carousel/CarouselStyle.jsx
@@ -1,10 +1,11 @@
 import styled, { css } from 'styled-components';
 
 const CarouselWrapper = styled.article`
-  width: 390px;
+  width: 100%;
   height: 404px;
   position: relative;
   overflow: hidden;
+  margin-top: -60px;
 `;
 
 const ImageBox = styled.ul`

--- a/src/components/common/Tabs/SpaceTabs.jsx
+++ b/src/components/common/Tabs/SpaceTabs.jsx
@@ -1,4 +1,6 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useRef } from 'react';
+import { useState } from 'react';
 import styled from 'styled-components';
 import { SPACES } from '../../../constants/spaces';
 
@@ -36,8 +38,47 @@ const StyledSpaceTabs = styled.nav`
 `;
 
 export default function SpaceTabs({ currentTab, onClick, scrollLeft }) {
+  const scrollRef = useRef(null);
+  const [isStart, setIsStart] = useState(false);
+  const [isDrag, setIsDrag] = useState(false);
+  const [startX, setStartX] = useState(0);
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollLeft = scrollLeft;
+    }
+  }, [scrollLeft]);
+
+  const handleDragStart = (e) => {
+    e.preventDefault();
+    setIsDrag(false);
+    setIsStart(true);
+    setStartX(e.pageX + scrollRef.current.scrollLeft);
+  };
+
+  const handleDragEnd = (e) => {
+    setIsStart(false);
+  };
+
+  const handleDragMove = (e) => {
+    if (isStart) {
+      setIsDrag(true);
+      scrollRef.current.scrollLeft = startX - e.pageX;
+    }
+  };
+
+  const handleClickTab = (e) => {
+    if (!isDrag) onClick(e);
+  };
+
   return (
     <StyledSpaceTabs
+      ref={scrollRef}
+      onMouseDown={handleDragStart}
+      onMouseMove={handleDragMove}
+      onMouseUp={handleDragEnd}
+      onMouseLeave={handleDragEnd}
+      onClick={handleClickTab}
     >
       {['전체', ...SPACES].map((space, index) => (
         <StyledSpaceTab key={index} className={index === currentTab ? 'active' : null}>

--- a/src/components/common/Tabs/SpaceTabs.jsx
+++ b/src/components/common/Tabs/SpaceTabs.jsx
@@ -1,22 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
-
-const spaces = [
-  '전체',
-  '원룸',
-  '거실',
-  '침실',
-  '주방',
-  '욕실',
-  '아이방',
-  '드레스룸',
-  '서재&작업실',
-  '베란다',
-  '사무공간',
-  '가구&소품',
-  '현관',
-  '외관&기타',
-];
+import { SPACES } from '../../../constants/spaces';
 
 const StyledSpaceTab = styled.button`
   font-weight: 500;
@@ -41,16 +25,21 @@ const StyledSpaceTab = styled.button`
 
 const StyledSpaceTabs = styled.nav`
   width: 100%;
-  padding: 20px 0 20px 16px;
+  padding: 20px 20px 20px 16px;
   display: flex;
   gap: 1rem;
   overflow-x: scroll;
+
+  ::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
-export default function SpaceTabs({ currentTab, ...rest }) {
+export default function SpaceTabs({ currentTab, onClick, scrollLeft }) {
   return (
-    <StyledSpaceTabs {...rest}>
-      {spaces.map((space, index) => (
+    <StyledSpaceTabs
+    >
+      {['전체', ...SPACES].map((space, index) => (
         <StyledSpaceTab key={index} className={index === currentTab ? 'active' : null}>
           {space}
         </StyledSpaceTab>

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -27,11 +27,19 @@ export default function HomePage() {
   `;
 
   const [currentTab, setCurrentTab] = useState(0);
+  const [filteredPosts, setFilteredPosts] = useState(posts);
+  const [scrollLeft, setScrollLeft] = useState(0);
 
   const handleClickTabButton = (e) => {
     const index = SPACES.indexOf(e.target.innerText) + 1;
     if (e.target.tagName === 'BUTTON') {
+      setScrollLeft(e.currentTarget.scrollLeft); // 버튼 클릭했을 때 scrollLeft 위치 유지
       setCurrentTab(index);
+      const filtered = posts.filter((post) => {
+        const parsedContent = JSON.parse(post.content);
+        return e.target.innerText === '전체' ? posts : parsedContent.space === e.target.innerText;
+      });
+      setFilteredPosts(filtered);
     }
   };
 

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -31,7 +31,7 @@ export default function HomePage() {
   const [scrollLeft, setScrollLeft] = useState(0);
 
   const handleClickTabButton = (e) => {
-    const index = SPACES.indexOf(e.target.innerText) + 1;
+    const index = ['전체', ...SPACES].indexOf(e.target.innerText);
     if (e.target.tagName === 'BUTTON') {
       setScrollLeft(e.currentTarget.scrollLeft); // 버튼 클릭했을 때 scrollLeft 위치 유지
       setCurrentTab(index);

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -1,5 +1,51 @@
 import React from 'react';
+import { posts, topLikedPosts } from '../../mock/mockData';
+import Carousel from '../../components/common/Carousel/Carousel';
+import SpaceTabs from '../../components/common/Tabs/SpaceTabs';
+import BasicLayout from '../../layout/BasicLayout';
+import PostList from '../../components/Profile/PostList/PostList';
+import styled from 'styled-components';
+import { useState } from 'react';
+import { SPACES } from '../../constants/spaces';
 
 export default function HomePage() {
-  return <div>Home</div>;
+  const Message = styled.p`
+    font-weight: 500;
+    font-size: ${({ theme }) => theme.fontSize.base};
+    color: ${({ theme }) => theme.colors.gray200};
+    padding-top: 52px;
+    text-align: center;
+  `;
+
+  const TabWrapper = styled.div`
+    border-radius: 16px 16px 0 0;
+    margin-top: -16px;
+    position: sticky;
+    top: 0;
+    z-index: 1;
+    background-color: ${({ theme }) => theme.colors.white};
+  `;
+
+  const [currentTab, setCurrentTab] = useState(0);
+
+  const handleClickTabButton = (e) => {
+    const index = SPACES.indexOf(e.target.innerText) + 1;
+    if (e.target.tagName === 'BUTTON') {
+      setCurrentTab(index);
+    }
+  };
+
+  return (
+    <BasicLayout type='home'>
+      <Carousel data={topLikedPosts} />
+      <TabWrapper>
+        <SpaceTabs currentTab={currentTab} onClick={handleClickTabButton} scrollLeft={scrollLeft} />
+      </TabWrapper>
+      {filteredPosts.length >= 1 ? (
+        <PostList selectedTab='grid' posts={filteredPosts} />
+      ) : (
+        <Message>작성된 게시물이 없습니다.</Message>
+      )}
+    </BasicLayout>
+  );
 }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
<!--수정/추가한 작업 내용을 설명해 주세요.-->
홈페이지 마크업 및 스와이프, 필터링 기능을 구현했다.
<br><br>

## 🔍 상세 작업 내용
<!-- 작업한 상세 내용을 설명해 주세요.-->
- 높은 좋아요 순으로 mock data를 받아와 상위 Carousel에 보여줬다.
- 게시글이 없다면 게시글이 없다는 화면을, 게시글이 있다면 카드 리스트 형태로 보여줬다.
- SpaceTabs가 옆으로 터치스크롤이 되게 했다.(스와이프)
- Mock 데이터를 받아와 탭에 따른 posts 데이터를 보여줬다.
- 아래로 스크롤했을 때 SpaceTabs가 맨 위에 붙게 했다.
<br><br>

## 💬 참고 사항
<!-- 참고할 만한 사항이 있다면 작성해 주세요. -->
- 탭 버튼을 클릭하여 데이터를 받아올 때 좌우 스크롤이 맨 앞으로 오는 버그 수정
- 버튼을 클릭한 상태로 스와이프시 버튼 클릭이 되는 버그 수정(스와이프와 클릭 이벤트 구분)
![image](https://github.com/FRONTENDSCHOOL5/final-14-BangKKuseok/assets/64193469/14763ae8-1575-4456-8ec0-e4bd2855cb55)

-  `position: sticky`를 사용하여 아래로 스크롤 시 tab이 맨 위에 붙음
![image](https://github.com/FRONTENDSCHOOL5/final-14-BangKKuseok/assets/64193469/739a0cad-1678-4a6b-8a81-32064546f2fb)

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #54

<br><br>
