### PR TITLE
🐛 fix: a 태그를 Link 컴포넌트로 대체하여 href 오류 해결 (#72)

### DIFF
--- a/src/components/LoginSignUp/Login/Login.jsx
+++ b/src/components/LoginSignUp/Login/Login.jsx
@@ -1,9 +1,10 @@
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import Input from '../../common/Input/Input';
 import Button from '../../common/Button/Button/Button';
 import { LoginHeader, LoginLogo, LoginBottomBox, LoginGoBack } from './LoginStyle';
 
-const Login = ({ onClickSignUpLink, onClickMainLink, onClickNextLink }) => {
+const Login = ({ onClickNextLink }) => {
   // 이메일의 값을 받아옴
   const [emailValue, setEmailValue] = useState('');
   const [passwordValue, setPasswordValue] = useState('');
@@ -20,13 +21,6 @@ const Login = ({ onClickSignUpLink, onClickMainLink, onClickNextLink }) => {
   // 버튼 활성화를 위해 만듦. 사용자가 입력하는 동안은 버튼 활성화가 되지만, 버튼을 눌렀을 때 이메일 혹은 비밀번호가 유효하지 않으면 값을 true로 바꿔줌으로써 버튼을 disabled 시킴
   const [isInValid, setIsInValid] = useState(true);
 
-  const handleGotoSignUp = () => {
-    onClickSignUpLink();
-  };
-
-  const handleGotoMain = () => {
-    onClickMainLink();
-  };
   // 이메일 입력값 받아오기
   const handleEmailChange = (e) => {
     const value = e.target.value;
@@ -148,8 +142,8 @@ const Login = ({ onClickSignUpLink, onClickMainLink, onClickNextLink }) => {
           로그인
         </Button>
         <LoginGoBack>
-          <a onClick={handleGotoSignUp}>회원가입</a>
-          <a onClick={handleGotoMain}>메인으로 돌아가기</a>
+          <Link to={'/signup'}>회원가입</Link>
+          <Link to={'/main'}>메인으로 돌아가기</Link>
         </LoginGoBack>
       </LoginBottomBox>
     </LoginHeader>

--- a/src/components/LoginSignUp/Main/Main.jsx
+++ b/src/components/LoginSignUp/Main/Main.jsx
@@ -1,15 +1,12 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import WhiteLogo from '../../../assets/images/logo-white.png';
 import SocialButton from '../../common/Button/SocialButton/SocialButton';
 import { MainPageWrapper, WhiteLogoImg, BottomBox, BtnBox, AccountSignUpBox } from './MainStyle';
 
-export default function Main({ onClickLoginLink, onClickSignUpLink }) {
+export default function Main({ onClickLoginLink }) {
   const handleGotoLogin = () => {
     onClickLoginLink();
-  };
-
-  const handleGotoSignUp = () => {
-    onClickSignUpLink();
   };
 
   return (
@@ -23,8 +20,8 @@ export default function Main({ onClickLoginLink, onClickSignUpLink }) {
           <SocialButton social='kakao'>카카오톡 계정으로 로그인</SocialButton>
           <SocialButton social='google'>구글 계정으로 로그인</SocialButton>
           <AccountSignUpBox>
-            <a>계정찾기</a>
-            <a onClick={handleGotoSignUp}>회원가입</a>
+            <Link to={''}>계정 찾기</Link>
+            <Link to={'/signup'}>회원가입</Link>
           </AccountSignUpBox>
         </BtnBox>
       </BottomBox>

--- a/src/components/LoginSignUp/SignUp/SignUp.jsx
+++ b/src/components/LoginSignUp/SignUp/SignUp.jsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { Link } from 'react-router-dom';
 import Input from '../../common/Input/Input';
 import Button from '../../common/Button/Button/Button';
 import { SignUpHeader, SignUpLogo, SignUpBottomBox, SignUpGoBack } from './SignUpStyle';
@@ -19,14 +20,6 @@ const SignUp = ({ onClickBackLink, onClickMainLink, onClickNextLink }) => {
 
   // 버튼 활성화를 위해 만듦. 사용자가 입력하는 동안은 버튼 활성화가 되지만, 버튼을 눌렀을 때 이메일 혹은 비밀번호가 유효하지 않으면 값을 true로 바꿔줌으로써 버튼을 disabled 시킴
   const [isInValid, setIsInValid] = useState(false);
-
-  const handleGotoLogin = () => {
-    onClickBackLink();
-  };
-
-  const handleGotoMain = () => {
-    onClickMainLink();
-  };
 
   // 이메일 입력값 받아오기
   const handleEmailChange = (e) => {
@@ -147,8 +140,8 @@ const SignUp = ({ onClickBackLink, onClickMainLink, onClickNextLink }) => {
           다음
         </Button>
         <SignUpGoBack>
-          <a onClick={handleGotoLogin}>로그인</a>
-          <a onClick={handleGotoMain}>메인으로 돌아가기</a>
+          <Link to={'/login'}>로그인</Link>
+          <Link to={'/main'}>메인으로 돌아가기</Link>
         </SignUpGoBack>
       </SignUpBottomBox>
     </SignUpHeader>

--- a/src/pages/LoginPage/LoginPage.jsx
+++ b/src/pages/LoginPage/LoginPage.jsx
@@ -7,16 +7,6 @@ export default function LoginPage() {
 
   const navigate = useNavigate();
 
-  const handleSignUpLink = () => {
-    setStep('회원가입');
-    navigate('/signup');
-  };
-
-  const handleMainLink = () => {
-    setStep('메인');
-    navigate('/main');
-  };
-
   const handleNextLink = () => {
     setStep('홈');
     navigate('/');
@@ -24,11 +14,7 @@ export default function LoginPage() {
 
   return (
     <>
-      <Login
-        onClickSignUpLink={handleSignUpLink}
-        onClickMainLink={handleMainLink}
-        onClickNextLink={handleNextLink}
-      />
+      <Login onClickNextLink={handleNextLink} />
     </>
   );
 }

--- a/src/pages/MainPage/MainPage.jsx
+++ b/src/pages/MainPage/MainPage.jsx
@@ -5,13 +5,9 @@ import Main from '../../components/LoginSignUp/Main/Main';
 export default function MainPage() {
   const navigate = useNavigate();
 
-  const handleSignUpLink = () => {
-    navigate('/signup');
-  };
-
   const handleLoginLink = () => {
     navigate('/login');
   };
 
-  return <Main onClickLoginLink={handleLoginLink} onClickSignUpLink={handleSignUpLink} />;
+  return <Main onClickLoginLink={handleLoginLink} />;
 }

--- a/src/pages/SignupPage/SignupPage.jsx
+++ b/src/pages/SignupPage/SignupPage.jsx
@@ -9,18 +9,10 @@ export default function SignupPage() {
   const navigate = useNavigate();
 
   const handleBackLink = () => {
-    if (step === '회원가입') {
-      setStep('로그인');
-      navigate('/login');
-    } else if (step === '프로필설정') {
+    if (step === '프로필설정') {
       setStep('회원가입');
       navigate('/signup');
     }
-  };
-
-  const handleMainLink = () => {
-    setStep('메인');
-    navigate('/main');
   };
 
   const handleNextLink = () => {
@@ -34,13 +26,7 @@ export default function SignupPage() {
 
   return (
     <>
-      {step === '회원가입' && (
-        <SignUp
-          onClickBackLink={handleBackLink}
-          onClickMainLink={handleMainLink}
-          onClickNextLink={handleNextLink}
-        />
-      )}
+      {step === '회원가입' && <SignUp onClickNextLink={handleNextLink} />}
       {step === '프로필설정' && (
         <SetUserProfile onClickBackLink={handleBackLink} onClickNextLink={handleNextLink} />
       )}


### PR DESCRIPTION
Link 컴포넌트를 사용하여 페이지 내에서의 전환과 이동을 구현하는 것이 적절하다고 판단하여 a태그를 Link컴포넌트로 대체하였다. 또한 필요없는 함수 및 코드들을 삭제하였다.

- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
a 태그를 Link 컴포넌트로 대체하여 href 오류를 해결하였고, 불필요한 함수 및 코드를 삭제하였다.

<br><br>

## 🔍 상세 작업 내용
새로 고침되어 다른 페이지로 이동하는 a태그보다는 Link 컴포넌트를 사용하여 페이지 내에서의 전환과 이동을 구현하는 것이 적절하다고 판단하여 변경하였다. 기존에 a 태그 내에 props로 전달해준 함수와 관련된 코드들은 삭제하였다.

<br><br>

## 💬 참고 사항
<!-- 참고할 만한 사항이 있다면 작성해 주세요. -->

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #72 

<br><br>
