### PR TITLE
♻️ refactor: SetUserProfile 컴포넌트 폼 입력 부분 분리

### DIFF
--- a/src/components/LoginSignUp/SetUserProfile/SetUserProfile.jsx
+++ b/src/components/LoginSignUp/SetUserProfile/SetUserProfile.jsx
@@ -1,101 +1,21 @@
-import React, { useState, useEffect } from 'react';
-import Input from '../../common/Input/Input';
+import React, { useState } from 'react';
 import Button from '../../common/Button/Button/Button';
-import ProfileImgUpload from '../../common/ProfileImageUpload/ProfileImageUpload';
 import {
   UserProfileWrapper,
   UserProfileHeader,
   ProfileMainTitle,
   ProfileSubTitle,
-  ImgUploadBox,
   UserProfileBottom,
   IsAlreadyUser,
 } from './SetUserProfileStyle';
+import SetUserProfileForm from './SetUserProfileForm';
 
 const SetUserProfile = ({ onClickBackLink, onClickNextLink }) => {
-  const [nameValue, setNameValue] = useState('');
-  const [IdValue, setIdValue] = useState('');
-  const [introValue, setIntroValue] = useState('');
-
-  const [nameError, setNameError] = useState('');
-  const [IdError, setIdError] = useState('');
-
-  const [isNameInValid, setIsNameInValid] = useState(false);
-  const [isIdInValid, setIsIdInValid] = useState(false);
-
-  const [isInValid, setIsInValid] = useState(false);
-
-  const handleGotoSignUpPage = () => {
-    onClickBackLink();
-  };
-
-  const handleNameChange = (e) => {
-    setNameError('');
-    setIsInValid(false);
-    const value = e.target.value;
-    setNameValue(value);
-  };
-
-  const handleIdChange = (e) => {
-    setIdError('');
-    setIsInValid(false);
-    const value = e.target.value;
-    setIdValue(value);
-  };
-
-  const handleIntroChange = (e) => {
-    const value = e.target.value;
-    setIntroValue(value);
-  };
-
-  useEffect(() => {
-    setNameError('');
-    setIsInValid(false);
-    if (!/^[a-zA-Z0-9가-힣]*$/.test(nameValue) || nameValue.length < 2 || nameValue.length > 10) {
-      setIsNameInValid(true);
-    } else {
-      setIsNameInValid(false);
-    }
-  }, [nameValue]);
-
-  const handleValidateName = () => {
-    if (isNameInValid) {
-      // 정규표현식 && 길이 문제
-      if (!/^[a-zA-Z0-9가-힣]*$/.test(nameValue) || nameValue.length < 2 || nameValue.length > 10) {
-        setNameError('2~10글자 이내 한글, 영문자, 숫자만 가능합니다.');
-        setIsNameInValid(true);
-      }
-    } else {
-      setNameError('');
-      setIsNameInValid(false);
-    }
-  };
-
-  const handleValidateId = () => {
-    if (!/^[a-zA-Z0-9_.]*$/.test(IdValue)) {
-      setIdError('영문, 숫자, 밑줄 및 마침표만 사용할 수 있습니다.');
-      setIsIdInValid(true);
-    } else {
-      setIdError('');
-      setIsIdInValid(false);
-    }
-    const lowercaseValue = IdValue.toLowerCase();
-    setIdValue(lowercaseValue);
-  };
+  const [isButtonActive, setIsButtonActive] = useState(false);
 
   const handleSubmit = (e) => {
     e.preventDefault();
-
-    handleValidateName();
-    handleValidateId();
-
-    setIsInValid(isNameInValid || isIdInValid);
-
-    console.log(isNameInValid, isIdInValid);
-
-    if (!isNameInValid && !isIdInValid) {
-      onClickNextLink();
-    }
+    onClickNextLink();
   };
 
   return (
@@ -103,53 +23,15 @@ const SetUserProfile = ({ onClickBackLink, onClickNextLink }) => {
       <UserProfileHeader>
         <ProfileMainTitle>프로필 설정</ProfileMainTitle>
         <ProfileSubTitle>나중에 얼마든지 변경할 수 있습니다.</ProfileSubTitle>
-        <ImgUploadBox>
-          <ProfileImgUpload />
-        </ImgUploadBox>
       </UserProfileHeader>
 
-      <Input
-        id='name'
-        inputType='text'
-        labelText='사용자 이름'
-        placeHolder='2~10자 이내여야 합니다.'
-        value={nameValue}
-        warningMsg={nameError}
-        onChange={handleNameChange}
-        onBlur={handleValidateName}
-        isInValid={isNameInValid}
-      />
-
-      <Input
-        id='id'
-        inputType='text'
-        labelText='계정 ID'
-        placeHolder='영문, 숫자, 특수문자(.),(_)만 사용 가능합니다.'
-        value={IdValue}
-        warningMsg={IdError}
-        onChange={handleIdChange}
-        onBlur={handleValidateId}
-        isInValid={isIdInValid}
-      />
-      <Input
-        id='intro'
-        inputType='text'
-        labelText='소개'
-        placeHolder='자신과 판매할 상품에 대해 소개해 주세요!'
-        value={introValue}
-        onChange={handleIntroChange}
-      />
+      <SetUserProfileForm setIsButtonActive={setIsButtonActive} />
 
       <UserProfileBottom>
-        <Button
-          type='submit'
-          size='lg'
-          onClick={handleSubmit}
-          disabled={nameValue === '' || IdValue === '' || isInValid}
-        >
+        <Button type='submit' size='lg' onClick={handleSubmit} disabled={!isButtonActive}>
           방꾸석 들어가기
         </Button>
-        <IsAlreadyUser onClick={handleGotoSignUpPage}>이전으로 돌아가기</IsAlreadyUser>
+        <IsAlreadyUser onClick={onClickBackLink}>이전으로 돌아가기</IsAlreadyUser>
       </UserProfileBottom>
     </UserProfileWrapper>
   );

--- a/src/components/LoginSignUp/SetUserProfile/SetUserProfileForm.jsx
+++ b/src/components/LoginSignUp/SetUserProfile/SetUserProfileForm.jsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useState } from 'react';
+import Input from '../../common/Input/Input';
+import { ImgUploadBox, ProfileForm } from './SetUserProfileFormStyle';
+import ProfileImgUpload from '../../common/ProfileImageUpload/ProfileImageUpload';
+
+export default function SetUserProfileForm({ setIsButtonActive, userData = '' }) {
+  const [nameValue, setNameValue] = useState(userData.username ?? '');
+  const [idValue, setIdValue] = useState(userData.accountname ?? '');
+  const [introValue, setIntroValue] = useState(userData.intro ?? '');
+
+  const [nameError, setNameError] = useState('');
+  const [idError, setIdError] = useState('');
+
+  const [isNameInValid, setIsNameInValid] = useState(true);
+  const [isIdInValid, setIsIdInValid] = useState(true);
+  const [isInValid, setIsInValid] = useState(true);
+
+  const handleNameChange = (e) => {
+    const value = e.target.value;
+    setNameValue(value);
+    setNameError('');
+  };
+
+  const handleIdChange = (e) => {
+    const value = e.target.value;
+    setIdValue(value);
+    setIdError('');
+  };
+
+  const handleIntroChange = (e) => {
+    const value = e.target.value;
+    setIntroValue(value);
+  };
+
+  const handleValidateName = () => {
+    if (!/^[a-zA-Z0-9가-힣]*$/.test(nameValue) || nameValue.length < 2 || nameValue.length > 10) {
+      setNameError('2~10글자 이내 한글, 영문자, 숫자만 가능합니다.');
+      setIsNameInValid(true);
+    } else {
+      setNameError('');
+      setIsNameInValid(false);
+    }
+  };
+
+  const handleValidateId = () => {
+    if (!/^[a-zA-Z0-9_.]*$/.test(idValue)) {
+      setIdError('영문, 숫자, 밑줄 및 마침표만 사용할 수 있습니다.');
+      setIsIdInValid(true);
+    } else {
+      setIdError('');
+      setIsIdInValid(false);
+    }
+    const lowercaseValue = idValue.toLowerCase();
+    setIdValue(lowercaseValue);
+  };
+
+  /**
+   * 이름과 id의 유효성이 변경될 때마다 전체 유효성 상태가 변경되며
+   * 전체 데이터 유효성 상태에 따라 버튼의 active 상태가 변경된다.
+   */
+  useEffect(() => {
+    setIsInValid(isNameInValid || isIdInValid);
+
+    if (isInValid) {
+      setIsButtonActive(false);
+    } else {
+      setIsButtonActive(true);
+    }
+  }, [isNameInValid, isIdInValid, isInValid, setIsButtonActive]);
+
+  return (
+    <ProfileForm>
+      <ImgUploadBox>
+        <ProfileImgUpload userImg={userData.image} />
+      </ImgUploadBox>
+
+      <Input
+        id='name'
+        inputType='text'
+        labelText='사용자 이름'
+        placeHolder='2~10자 이내여야 합니다.'
+        value={nameValue}
+        warningMsg={nameError}
+        onChange={handleNameChange}
+        onBlur={handleValidateName}
+        isInValid={isNameInValid}
+      />
+
+      <Input
+        id='id'
+        inputType='text'
+        labelText='계정 ID'
+        placeHolder='영문, 숫자, 특수문자(.),(_)만 사용 가능합니다.'
+        value={idValue}
+        warningMsg={idError}
+        onChange={handleIdChange}
+        onBlur={handleValidateId}
+        isInValid={isIdInValid}
+      />
+      <Input
+        id='intro'
+        inputType='text'
+        labelText='소개'
+        placeHolder='자신과 판매할 상품에 대해 소개해 주세요!'
+        value={introValue}
+        onChange={handleIntroChange}
+      />
+    </ProfileForm>
+  );
+}

--- a/src/components/LoginSignUp/SetUserProfile/SetUserProfileFormStyle.jsx
+++ b/src/components/LoginSignUp/SetUserProfile/SetUserProfileFormStyle.jsx
@@ -1,0 +1,9 @@
+import styled from 'styled-components';
+
+export const ImgUploadBox = styled.div`
+  width: 110px;
+  height: 110px;
+  margin: 0 auto 30px auto;
+`;
+
+export const ProfileForm = styled.form``;

--- a/src/components/LoginSignUp/SetUserProfile/SetUserProfileStyle.jsx
+++ b/src/components/LoginSignUp/SetUserProfile/SetUserProfileStyle.jsx
@@ -25,17 +25,6 @@ export const ProfileSubTitle = styled.p`
   font-size: ${({ theme }) => theme.fontSize.sm};
   color: ${({ theme }) => theme.colors.gray300};
   text-align: center;
-  margin: 0 auto 30px;
-`;
-
-export const ImgUploadBox = styled.div`
-  width: 110px;
-  height: 110px;
-  margin: 0 auto;
-`;
-
-export const ProfileImgUpload = styled.img`
-  object-fit: cover;
 `;
 
 export const UserProfileBottom = styled.div`

--- a/src/components/common/ProfileImageUpload/ProfileImageUpload.jsx
+++ b/src/components/common/ProfileImageUpload/ProfileImageUpload.jsx
@@ -1,11 +1,11 @@
 import React, { useRef, useState } from 'react';
 import defaultProfImg from '../../../assets/images/profile.png';
 import profUploadImg from '../../../assets/images/prof-upload.png';
-import { ProfileImageUploadWrapper, UploadForm } from './ProfileImageUploadStyle';
+import { ProfileImageUploadWrapper, UploadBox } from './ProfileImageUploadStyle';
 
-export default function ProfileImageUpload() {
+export default function ProfileImageUpload({ userImg }) {
   //프로필 이미지 저장 변수
-  const [profImg, setProfImg] = useState(defaultProfImg);
+  const [profImg, setProfImg] = useState(userImg ?? defaultProfImg);
   const imgRef = useRef();
 
   // 이미지 업로드 시 profImg 변경해서 이미지 미리보기 함수
@@ -21,7 +21,7 @@ export default function ProfileImageUpload() {
   return (
     <ProfileImageUploadWrapper>
       <img src={profImg} alt='프로필 이미지' />
-      <UploadForm>
+      <UploadBox>
         <input
           type='file'
           id='profUpload'
@@ -33,7 +33,7 @@ export default function ProfileImageUpload() {
         <label htmlFor='profUpload'>
           <img src={profUploadImg} alt='업로드 버튼 이미지' />
         </label>
-      </UploadForm>
+      </UploadBox>
     </ProfileImageUploadWrapper>
   );
 }

--- a/src/components/common/ProfileImageUpload/ProfileImageUploadStyle.jsx
+++ b/src/components/common/ProfileImageUpload/ProfileImageUploadStyle.jsx
@@ -12,7 +12,7 @@ const ProfileImageUploadWrapper = styled.div`
   }
 `;
 
-const UploadForm = styled.form`
+const UploadBox = styled.div`
   position: absolute;
   inset: auto 0 0 auto;
   width: 36px;
@@ -24,4 +24,4 @@ const UploadForm = styled.form`
   }
 `;
 
-export { ProfileImageUploadWrapper, UploadForm };
+export { ProfileImageUploadWrapper, UploadBox };


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?
<br>

## ⚡ PR 한 줄 요약
SetUserProfile 컴포넌트를 SetUserProfileForm 과 분리

<br><br>

## 🔍 상세 작업 내용
- SetUserProfile에서 사용되는 상태값과 handler 이벤트를 SetUserProfileForm으로 분리했다.
- __InValid 초기값 세팅을 false -> true로 변경하여 로직의 오류를 수정했다.
- 필요없는 코드 줄을 삭제했다.
- SetUserProfilForm에 기본값으로 유저 데이터를 사용할 수 있게 props를 추가했다.

<br><br>

## 💬 참고 사항
- 회원가입 페이지에서 사용 방법
```jsx
// 다음 단계로 넘어가기 위한 버튼을 활성화 해줄 setState 함수를 전달
<SetUserProfileForm setIsButtonActive={setIsButtonActive} />
```

- 프로필 수정 페이지에서 사용 방법
```jsx
// 현재 로그인된 사용자의 정보를 userData props에 넘겨주어 수정 페이지에서 input의 기본 값으로 사용
<SetUserProfileForm userData={profileData.profile} setIsButtonActive={setIsButtonActive} />
```

추후 Form 컴포넌트에서의 상태값을 객체로 합쳐주어 API 요청에 사용할 수 있게끔 작업을 진행해야한다.

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #78 

<br><br>
