### PR TITLE
✨ feat: 프로필 수정 페이지 마크업 및 API 연동하여 수정 기능 구현

### DIFF
--- a/src/api/profileApi.js
+++ b/src/api/profileApi.js
@@ -18,3 +18,11 @@ export const getMyProfile = async () => {
   }
 };
 
+export const updateProfile = async (formData) => {
+  try {
+    const response = await accessInstance.put(`/user`, formData);
+    return response.data;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/api/profileApi.js
+++ b/src/api/profileApi.js
@@ -8,3 +8,13 @@ export const getProfile = async (accountname) => {
     console.error(error);
   }
 };
+
+export const getMyProfile = async () => {
+  try {
+    const response = await accessInstance.get(`/user/myinfo`);
+    return response.data;
+  } catch (error) {
+    console.error(error);
+  }
+};
+

--- a/src/components/LoginSignUp/SetUserProfile/SetUserProfileForm.jsx
+++ b/src/components/LoginSignUp/SetUserProfile/SetUserProfileForm.jsx
@@ -3,10 +3,11 @@ import Input from '../../common/Input/Input';
 import { ImgUploadBox, ProfileForm } from './SetUserProfileFormStyle';
 import ProfileImgUpload from '../../common/ProfileImageUpload/ProfileImageUpload';
 
-export default function SetUserProfileForm({ setIsButtonActive, userData = '' }) {
-  const [nameValue, setNameValue] = useState(userData.username ?? '');
-  const [idValue, setIdValue] = useState(userData.accountname ?? '');
-  const [introValue, setIntroValue] = useState(userData.intro ?? '');
+export default function SetUserProfileForm({ setIsButtonActive, myData = '', setData }) {
+  const [nameValue, setNameValue] = useState(myData.username ?? '');
+  const [idValue, setIdValue] = useState(myData.accountname ?? '');
+  const [introValue, setIntroValue] = useState(myData.intro ?? '');
+  const [image, setImage] = useState(myData.image ?? '');
 
   const [nameError, setNameError] = useState('');
   const [idError, setIdError] = useState('');
@@ -68,10 +69,30 @@ export default function SetUserProfileForm({ setIsButtonActive, userData = '' })
     }
   }, [isNameInValid, isIdInValid, isInValid, setIsButtonActive]);
 
+  /**
+   * 프로필 설정 값이 변경되면 상위 컴포넌트의 data를 변경한다.
+   */
+  useEffect(() => {
+    setData({
+      username: nameValue,
+      accountname: idValue,
+      intro: introValue,
+      image: image,
+    });
+  }, [nameValue, idValue, introValue, image]);
+
+  /**
+   * ProfileForm이 초기에 렌더링 되었을 때 Validate 체크
+   */
+  useEffect(() => {
+    handleValidateId();
+    handleValidateName();
+  }, []);
+
   return (
     <ProfileForm>
       <ImgUploadBox>
-        <ProfileImgUpload userImg={userData.image} />
+        <ProfileImgUpload userImg={myData.image} setNewProfileImage={setImage} />
       </ImgUploadBox>
 
       <Input

--- a/src/components/Profile/ProfileCard/ProfileCard.jsx
+++ b/src/components/Profile/ProfileCard/ProfileCard.jsx
@@ -70,7 +70,11 @@ export default function ProfileCard({ profile }) {
           </>
         ) : (
           <>
-            <Button size='md' variant='line' onClick={() => navigate('/profile/edit')}>
+            <Button
+              size='md'
+              variant='line'
+              onClick={() => navigate('/profile/edit', { state: profile })}
+            >
               프로필 수정
             </Button>
             <Button size='md' onClick={() => navigate('/product/upload')}>

--- a/src/components/common/Header/Header.jsx
+++ b/src/components/common/Header/Header.jsx
@@ -54,6 +54,17 @@ export default function Header({
         </button>
       </HeaderWrapper>
     ),
+    profileEdit: (
+      <HeaderWrapper type={type}>
+        <button type='button' onClick={onClickLeftButton}>
+          <BackIcon stroke='#000' />
+        </button>
+        <HeaderH2>{title}</HeaderH2>
+        <Button disabled={!isBtnActive} size='sm' onClick={onClickRightButton}>
+          {btnText}
+        </Button>
+      </HeaderWrapper>
+    ),
     post: (
       <HeaderWrapper type={type}>
         <button type='button' onClick={onClickLeftButton}>

--- a/src/components/common/ProfileImageUpload/ProfileImageUpload.jsx
+++ b/src/components/common/ProfileImageUpload/ProfileImageUpload.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import defaultProfImg from '../../../assets/images/profile.png';
 import profUploadImg from '../../../assets/images/prof-upload.png';
 import { ProfileImageUploadWrapper, UploadBox } from './ProfileImageUploadStyle';

--- a/src/components/common/ProfileImageUpload/ProfileImageUpload.jsx
+++ b/src/components/common/ProfileImageUpload/ProfileImageUpload.jsx
@@ -1,9 +1,9 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import defaultProfImg from '../../../assets/images/profile.png';
 import profUploadImg from '../../../assets/images/prof-upload.png';
 import { ProfileImageUploadWrapper, UploadBox } from './ProfileImageUploadStyle';
 
-export default function ProfileImageUpload({ userImg }) {
+export default function ProfileImageUpload({ userImg, setNewProfileImage }) {
   //프로필 이미지 저장 변수
   const [profImg, setProfImg] = useState(userImg ?? defaultProfImg);
   const imgRef = useRef();
@@ -15,6 +15,7 @@ export default function ProfileImageUpload({ userImg }) {
     reader.readAsDataURL(file);
     reader.onloadend = () => {
       setProfImg(reader.result);
+      setNewProfileImage(reader.result);
     };
   };
 

--- a/src/pages/ProfilePage/ProfileEditPage/ProfileEditPage.jsx
+++ b/src/pages/ProfilePage/ProfileEditPage/ProfileEditPage.jsx
@@ -1,5 +1,57 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import BasicLayout from '../../../layout/BasicLayout';
+import SetUserProfileForm from '../../../components/LoginSignUp/SetUserProfile/SetUserProfileForm';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { updateProfile } from '../../../api/profileApi';
+import { useMutation } from 'react-query';
 
 export default function ProfileEditPage() {
-  return <div>ProfileEditPage</div>;
+  const [isButtonActive, setIsButtonActive] = useState(false);
+  const [newProfile, setNewProfile] = useState({
+    username: '',
+    accountname: '',
+    intro: '',
+    image: '',
+  });
+
+  const navigate = useNavigate();
+  const location = useLocation();
+  const myData = location.state;
+
+  const updateProfileMutation = useMutation((formData) => updateProfile(formData), {
+    onSuccess: () => {
+      navigate('/profile');
+    },
+    onError: () => {
+      console.error('프로필 수정 실패');
+    },
+  });
+
+  const handleClickSaveButton = () => {
+    updateProfileMutation.mutate({
+      user: {
+        username: newProfile.username,
+        accountname: newProfile.accountname,
+        intro: newProfile.intro,
+        image: newProfile.image,
+      },
+    });
+  };
+
+  return (
+    <BasicLayout
+      type='profileEdit'
+      btnText='저장'
+      isBtnActive={isButtonActive}
+      isNonNav={true}
+      onClickLeftButton={() => navigate(-1)}
+      onClickRightButton={handleClickSaveButton}
+    >
+      <SetUserProfileForm
+        myData={myData}
+        setIsButtonActive={setIsButtonActive}
+        setData={setNewProfile}
+      />
+    </BasicLayout>
+  );
 }

--- a/src/pages/ProfilePage/ProfileEditPage/ProfileEditPage.jsx
+++ b/src/pages/ProfilePage/ProfileEditPage/ProfileEditPage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import BasicLayout from '../../../layout/BasicLayout';
 import SetUserProfileForm from '../../../components/LoginSignUp/SetUserProfile/SetUserProfileForm';
 import { useLocation, useNavigate } from 'react-router-dom';

--- a/src/pages/ProfilePage/ProfilePage/ProfilePage.jsx
+++ b/src/pages/ProfilePage/ProfilePage/ProfilePage.jsx
@@ -10,9 +10,9 @@ import ListModal from '../../../components/common/BottomSheet/ListModal';
 import BasicModal from '../../../components/common/BottomSheet/BasicModal';
 import ProductDetailCard from '../../../components/Profile/ProductDetailCard/ProductDetailCard';
 import { posts, products } from '../../../mock/mockData';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
 import { useQuery } from 'react-query';
-import { getProfile } from '../../../api/profileApi';
+import { getMyProfile, getProfile } from '../../../api/profileApi';
 
 const ProfilePageWrapper = styled.main``;
 
@@ -31,12 +31,17 @@ export default function ProfilePage() {
   const [isShowMorePost, setIsShowMorePost] = useState(false);
   const [isShowProductDetail, setIsShowProductDetail] = useState(false);
 
-  // getProfile에는 accountname 넘기기
-  const { data: profileData, isLoading: isProfileLoading } = useQuery('myProfile', () =>
-    getProfile('test333'),
+  const navigate = useNavigate();
+  const { accountname: accountnameByParams } = useParams();
+
+  const { data: userProfileData, isLoading: isUserProfileLoading } = useQuery('userProfile', () =>
+    accountnameByParams ? getProfile(accountnameByParams) : null,
   );
 
-  const navigate = useNavigate();
+  const { data: myProfileData, isLoading: isMyProfileLoading } = useQuery(
+    'myProfile',
+    getMyProfile,
+  );
 
   const handleClickTabButton = (tabId) => {
     setSelectedTab(tabId);
@@ -71,9 +76,11 @@ export default function ProfilePage() {
       onClickRightButton={handleClickMoreProfileButton}
     >
       <ProfilePageWrapper>
-        {!isProfileLoading && (
+        {(accountnameByParams ? !isUserProfileLoading : !isMyProfileLoading) && (
           <>
-            <ProfileCard profile={profileData.profile} />
+            <ProfileCard
+              profile={accountnameByParams ? userProfileData.profile : myProfileData.user}
+            />
             <ProductList products={products} onClick={handleClickProduct} />
             {posts.length > 0 ? (
               <>

--- a/src/pages/ProfilePage/ProfilePage/ProfilePage.jsx
+++ b/src/pages/ProfilePage/ProfilePage/ProfilePage.jsx
@@ -9,8 +9,10 @@ import BottomSheet from '../../../components/common/BottomSheet/BottomSheet';
 import ListModal from '../../../components/common/BottomSheet/ListModal';
 import BasicModal from '../../../components/common/BottomSheet/BasicModal';
 import ProductDetailCard from '../../../components/Profile/ProductDetailCard/ProductDetailCard';
-import { posts, products, profile } from '../../../mock/mockData';
+import { posts, products } from '../../../mock/mockData';
 import { useNavigate } from 'react-router-dom';
+import { useQuery } from 'react-query';
+import { getProfile } from '../../../api/profileApi';
 
 const ProfilePageWrapper = styled.main``;
 
@@ -22,12 +24,17 @@ const Message = styled.p`
   text-align: center;
 `;
 
-export default function MyProfile() {
+export default function ProfilePage() {
   const [selectedTab, setSelectedTab] = useState('list');
   const [selectedProduct, setSelectedProduct] = useState('');
   const [isShowMoreProfile, setIsShowMoreProfile] = useState(false);
   const [isShowMorePost, setIsShowMorePost] = useState(false);
   const [isShowProductDetail, setIsShowProductDetail] = useState(false);
+
+  // getProfile에는 accountname 넘기기
+  const { data: profileData, isLoading: isProfileLoading } = useQuery('myProfile', () =>
+    getProfile('test333'),
+  );
 
   const navigate = useNavigate();
 
@@ -64,20 +71,24 @@ export default function MyProfile() {
       onClickRightButton={handleClickMoreProfileButton}
     >
       <ProfilePageWrapper>
-        <ProfileCard profile={profile} />
-        <ProductList products={products} onClick={handleClickProduct} />
-        {posts.length > 0 ? (
+        {!isProfileLoading && (
           <>
-            <ViewTabs selectedTab={selectedTab} onClick={handleClickTabButton} />
-            <PostList
-              selectedTab={selectedTab}
-              posts={posts}
-              moreInfo={false}
-              onClick={handleClickMorePostButton}
-            />
+            <ProfileCard profile={profileData.profile} />
+            <ProductList products={products} onClick={handleClickProduct} />
+            {posts.length > 0 ? (
+              <>
+                <ViewTabs selectedTab={selectedTab} onClick={handleClickTabButton} />
+                <PostList
+                  selectedTab={selectedTab}
+                  posts={posts}
+                  moreInfo={false}
+                  onClick={handleClickMorePostButton}
+                />
+              </>
+            ) : (
+              <Message>작성된 게시물이 없습니다.</Message>
+            )}
           </>
-        ) : (
-          <Message>작성된 게시물이 없습니다.</Message>
         )}
 
         {/* -- BottomSheet */}

--- a/src/pages/ProfilePage/UserProfilePage/UserProfilePage.jsx
+++ b/src/pages/ProfilePage/UserProfilePage/UserProfilePage.jsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function UserProfilePage() {
-  return <div>UserProfile</div>;
-}

--- a/src/pages/Router.jsx
+++ b/src/pages/Router.jsx
@@ -9,7 +9,7 @@ import SearchPage from './SearchPage/SearchPage';
 import PostPage from './PostPage/PostPage/PostPage';
 import PostUploadPage from './PostPage/PostUploadPage/PostUploadPage';
 import PostEditPage from './PostPage/PostEditPage/PostEditPage';
-import MyProfilePage from './ProfilePage/MyProfilePage/MyProfilePage';
+import ProfilePage from './ProfilePage/ProfilePage/ProfilePage';
 import ProfileEditPage from './ProfilePage/ProfileEditPage/ProfileEditPage';
 import FollowersPage from './ProfilePage/FollowPage/FollowersPage/FollowersPage';
 import FollowingsPage from './ProfilePage/FollowPage/FollowingsPage/FollowingsPage';
@@ -32,10 +32,10 @@ export default function AppRouter() {
         <Route path='/post/:postId' element={<PostPage />} />
         <Route path='/post/:postId/edit' element={<PostEditPage />} />
         <Route path='/profile'>
-          <Route index element={<MyProfilePage />} />
+          <Route index element={<ProfilePage />} />
           <Route path='edit' element={<ProfileEditPage />} />
           <Route path=':accountname'>
-            <Route index element={<MyProfilePage />} />
+            <Route index element={<ProfilePage />} />
             <Route path='followers' element={<FollowersPage />} />
             <Route path='followings' element={<FollowingsPage />} />
           </Route>


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
프로필 수정 페이지를 마크업하고 API를 연동하여 수정 기능을 구현했다.

<br><br>

## 🔍 상세 작업 내용
- MyProfilePage와 UserProfilePage를 ProfilePage로 통합하였다.
- url의 params에 따라 내 정보 데이터 패칭/유저 정보 데이터 패칭을 분리하여 실행했다.
- 프로필 수정 버튼을 눌렀을 때 현재 내 프로필 정보를 넘겨주어 프로필 수정 페이지에 기존 프로필 정보가 보이게 했다.
- 프로필 수정이 완료되면 프로필 페이지로 이동하게 했다.

<br><br>

## 💬 참고 사항
- 회원가입 프로필 설정에서 SetUserProfileForm을 사용할 때는 아래와 같이 사용하면 됩니다!
```jsx
  const [isButtonActive, setIsButtonActive] = useState(false);
  const [profile, setProfile] = useState({
    username: '',
    accountname: '',
    intro: '',
    image: '',
  });

return(
   // ....
  <SetUserProfileForm
      setIsButtonActive={setIsButtonActive}
      setData={setProfile}
    />
)
```

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #71 

<br><br>
