### PR TITLE
🐛 fix: 게시글 업로드 시 이미지 변경 취소 오류와 상품목록 조건의 오류 발생

### DIFF
--- a/src/components/PostUpload/ModalProductList/ModalProductList.jsx
+++ b/src/components/PostUpload/ModalProductList/ModalProductList.jsx
@@ -11,7 +11,7 @@ export default function ModalProductList({ setIsShow, setTagStep, setIsBubbleSho
 
   return (
     <ModalProductListWrapper>
-      {canSelectItems.length > 1 ? (
+      {canSelectItems.length > 0 ? (
         canSelectItems.map((item) => (
           <ModalProductItem
             data={item}

--- a/src/components/PostUpload/PostImgUpload/PostImgUpload.jsx
+++ b/src/components/PostUpload/PostImgUpload/PostImgUpload.jsx
@@ -9,13 +9,15 @@ export default function PostImgUpload({ setPostImg, setIsBtnActive }) {
   // 이미지 업로드 시 postImg 변경해서 이미지 미리보기 함수
   const HandleUploadPostImg = () => {
     const file = imgRef.current.files[0];
-    const reader = new FileReader();
-    reader.readAsDataURL(file);
-    reader.onloadend = () => {
-      setPostImg(file);
-      setPreviewImg(reader.result);
-      setIsBtnActive(true);
-    };
+    if (file) {
+      const reader = new FileReader();
+      reader.readAsDataURL(file);
+      reader.onloadend = () => {
+        setPostImg(file);
+        setPreviewImg(reader.result);
+        setIsBtnActive(true);
+      };
+    }
   };
 
   //초기에 박스 클릭해도 업로드가 가능하도록


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
<!--수정/추가한 작업 내용을 설명해 주세요.-->
게시글 업로드와 수정에서 이미지 변경 취소 시 오류와 게시글 등록 시 태그할 상품목록이 1개 남아있음에도 목록에 뜨지 않는 문제를 해결했다.

<br><br>

## 🔍 상세 작업 내용
<!-- 작업한 상세 내용을 설명해 주세요.-->
- 태그할 수 있는 상품목록이 보이는 조건의 비교문을 잘못 작성하여 발생한 문제로, 해결했다.
- 새로운 파일이 들어와야 이미지를 변경하도록 file이 있을때 함수를 실행하도록 if문 안으로 넣어 문제를 해결했다. 

<br><br>

## 💬 참고 사항
<!-- 참고할 만한 사항이 있다면 작성해 주세요. -->

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #92 

<br><br>
