### PR TITLE
🐛 fix: 프로필 수정 시 이미지 변경 후, 다시 업로드 버튼을 누르고 취소할 경우 발생하는 오류 해결

### DIFF
--- a/src/components/common/ProfileImageUpload/ProfileImageUpload.jsx
+++ b/src/components/common/ProfileImageUpload/ProfileImageUpload.jsx
@@ -11,12 +11,14 @@ export default function ProfileImageUpload({ userImg, setNewProfileImage }) {
   // 이미지 업로드 시 profImg 변경해서 이미지 미리보기 함수
   const getProfImg = () => {
     const file = imgRef.current.files[0];
-    const reader = new FileReader();
-    reader.readAsDataURL(file);
-    reader.onloadend = () => {
-      setProfImg(reader.result);
-      setNewProfileImage(reader.result);
-    };
+    if (file) {
+      const reader = new FileReader();
+      reader.readAsDataURL(file);
+      reader.onloadend = () => {
+        setProfImg(reader.result);
+        setNewProfileImage(reader.result);
+      };
+    }
   };
 
   return (


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
프로필 수정 시 이미지 변경 후, 다시 업로드 버튼을 누르고 취소할 경우 발생하는 오류를 해결했다.

<br><br>

## 🔍 상세 작업 내용
- imgRef 즉, `input type=file` 에서 선택된 이미지가 없다면 File API가 실행되지 않고, 선택된 이미지가 있다면 File API가 실행되게 함으로써 에러를 해결하였다.

<br><br>

## 💬 참고 사항
이미지 선택 시 이미지 크기가 특정 값을 넘어가면 업로드 오류가 발생한다.

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #89 

<br><br>
