### PR TITLE
✨ feat: ProfilePage 사용자에 따른 모달창 구분 및 Confirm 연결

### DIFF
--- a/src/api/postApi.js
+++ b/src/api/postApi.js
@@ -1,5 +1,14 @@
 import { accessInstance } from './axiosInstance';
 
+export const getMyPost = async (accountname) => {
+  try {
+    const response = await accessInstance.get(`/post/${accountname}/userpost`);
+    return response.data.post;
+  } catch (error) {
+    console.error(error);
+  }
+};
+
 export const uploadPost = async (postData) => {
   try {
     const response = await accessInstance.post(`/post`, postData);

--- a/src/api/productApi.js
+++ b/src/api/productApi.js
@@ -1,0 +1,10 @@
+import { accessInstance } from './axiosInstance';
+
+export const deleteProduct = async (productId) => {
+  try {
+    const response = await accessInstance.delete(`/product/${productId}`);
+    return response.data;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/api/profileApi.js
+++ b/src/api/profileApi.js
@@ -3,7 +3,7 @@ import { accessInstance } from './axiosInstance';
 export const getProfile = async (accountname) => {
   try {
     const response = await accessInstance.get(`/profile/${accountname}`);
-    return response.data;
+    return response.data.profile;
   } catch (error) {
     console.error(error);
   }
@@ -12,7 +12,7 @@ export const getProfile = async (accountname) => {
 export const getMyProfile = async () => {
   try {
     const response = await accessInstance.get(`/user/myinfo`);
-    return response.data;
+    return response.data.user;
   } catch (error) {
     console.error(error);
   }

--- a/src/components/Profile/PostList/PostList.jsx
+++ b/src/components/Profile/PostList/PostList.jsx
@@ -3,22 +3,21 @@ import PostCard from '../../common/Card/PostCard/PostCard';
 import Gallery from '../../common/Gallery/Gallery';
 import UserSimpleInfo from '../../common/UserSimpleInfo/UserSimpleInfo/UserSimpleInfo';
 import { PostCardList, PostListWrapper } from './PostListStyle';
-import { filterPosts } from '../../../utils/filterPosts';
-import { profile } from '../../../mock/mockData';
+import { filterUserPosts } from '../../../utils/filterPosts';
 
-export default function PostList({ selectedTab, posts, moreInfo, onClick }) {
+export default function PostList({ selectedTab, profile, posts, moreInfo, onClick }) {
   const layout = {
     list: (
       <PostCardList>
         {posts.map((item) => (
-          <li key={item._id}>
-            <UserSimpleInfo profile={profile} type={'more'} onClick={onClick} />
+          <li key={item.id}>
+            <UserSimpleInfo profile={profile} type={'more'} onClick={() => onClick(item)} />
             <PostCard data={item} moreInfo={moreInfo} />
           </li>
         ))}
       </PostCardList>
     ),
-    grid: <Gallery data={filterPosts(posts)} />,
+    grid: <Gallery data={filterUserPosts(posts)} />,
   };
 
   return (

--- a/src/components/Profile/ProductDetailCard/ProductDetailCard.jsx
+++ b/src/components/Profile/ProductDetailCard/ProductDetailCard.jsx
@@ -10,7 +10,7 @@ import {
   ProductPrice,
 } from './ProductDetailCardStyle';
 
-export default function ProductDetailCard({ selectedProduct }) {
+export default function ProductDetailCard({ isMyProfile, selectedProduct, onClick }) {
   const { itemName, price, link, itemImage } = selectedProduct[0];
   const { name, keyword } = JSON.parse(itemName);
 
@@ -29,14 +29,19 @@ export default function ProductDetailCard({ selectedProduct }) {
         <ProductKeyword>{keyword}</ProductKeyword>
       </ProductInfoWrapper>
       <ProductActionWrapper>
-        {/* TODO: API 연동 후 현재 사용자 토큰과 페이지 param이 같지 않다면 웹 사이트에서 보기 버튼만 화면에 렌더링 */}
         <Button size='lg' onClick={handleClickOpenSite}>
           웹사이트에서 보기
         </Button>
-        <Button size='lg' variant='line'>
-          삭제
-        </Button>
-        <Button size='lg'>수정</Button>
+        {isMyProfile && (
+          <>
+            <Button size='lg' variant='line' onClick={onClick}>
+              삭제
+            </Button>
+            <Button size='lg' onClick={onClick}>
+              수정
+            </Button>
+          </>
+        )}
       </ProductActionWrapper>
     </ProductDetailCardWrapper>
   );

--- a/src/components/Profile/ProfileCard/ProfileCard.jsx
+++ b/src/components/Profile/ProfileCard/ProfileCard.jsx
@@ -14,7 +14,7 @@ import {
 } from './ProfileCardStyle';
 import { useParams, Link, useNavigate } from 'react-router-dom';
 
-export default function ProfileCard({ profile }) {
+export default function ProfileCard({ profile, isMyProfile }) {
   const { accountname: accountnameByParams } = useParams();
 
   const [isFollow, setIsFollow] = useState(false);
@@ -54,7 +54,7 @@ export default function ProfileCard({ profile }) {
         <Intro>{profile.intro}</Intro>
       </UserInfoBox>
       <UserActionBox>
-        {accountnameByParams ? (
+        {!isMyProfile ? (
           <>
             <Link to={`/chat/${accountnameByParams}`} title='상대방과 채팅하기'></Link>
             {isFollow ? (

--- a/src/components/common/Card/PostCard/PostCard.jsx
+++ b/src/components/common/Card/PostCard/PostCard.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import Heart from '../Heart/Heart';
 import commentIcon from '../../../../assets/icons/icon-message-small.svg';
 import { HeartCommentList, PostCardWrapper, PostDetail, PostInfoBox, Space } from './PostCardStyle';
@@ -6,7 +6,7 @@ import { convertDateFormat } from '../../../../utils/getTime';
 import { useNavigate } from 'react-router-dom';
 
 export default function PostCard({ data, moreInfo = false }) {
-  const { _id, content, image, hearted, heartCount, comments, createdAt } = data;
+  const { id, content, image, hearted, heartCount, comments, createdAt } = data;
   const { space, detail } = JSON.parse(content);
 
   const navigate = useNavigate();
@@ -21,7 +21,7 @@ export default function PostCard({ data, moreInfo = false }) {
             <Heart hearted={hearted} />
             {heartCount}
           </li>
-          <li onClick={moreInfo ? null : () => navigate(`/post/${_id}`)}>
+          <li onClick={moreInfo ? null : () => navigate(`/post/${id}`)}>
             <img src={commentIcon} alt='댓글' />
             {comments.length}
           </li>

--- a/src/components/common/UserSimpleInfo/UserSimpleInfo/UserSimpleStyle.jsx
+++ b/src/components/common/UserSimpleInfo/UserSimpleInfo/UserSimpleStyle.jsx
@@ -25,6 +25,7 @@ const UserInfoBox = styled.div`
   img {
     width: 50px;
     height: 50px;
+    object-fit: cover;
     border-radius: 50%;
     margin-right: 12px;
   }

--- a/src/pages/ProductPage/ProductEditPage/ProductEditPage.jsx
+++ b/src/pages/ProductPage/ProductEditPage/ProductEditPage.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function ProductEditPage() {
+  return <div>ProductEditPage</div>;
+}

--- a/src/pages/ProductPage/ProductPage.jsx
+++ b/src/pages/ProductPage/ProductPage.jsx
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default function ProductPage() {
-  return <div>Product</div>;
-}

--- a/src/pages/ProductPage/ProductUploadPage/ProductUploadPage.jsx
+++ b/src/pages/ProductPage/ProductUploadPage/ProductUploadPage.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function ProductUploadPage() {
+  return <div>ProductUploadPage</div>;
+}

--- a/src/pages/ProfilePage/ProfilePage/ProfilePage.jsx
+++ b/src/pages/ProfilePage/ProfilePage/ProfilePage.jsx
@@ -9,7 +9,9 @@ import BottomSheet from '../../../components/common/BottomSheet/BottomSheet';
 import ListModal from '../../../components/common/BottomSheet/ListModal';
 import BasicModal from '../../../components/common/BottomSheet/BasicModal';
 import ProductDetailCard from '../../../components/Profile/ProductDetailCard/ProductDetailCard';
-import { posts, products } from '../../../mock/mockData';
+import Confirm from '../../../components/common/Confirm/Confirm';
+import Spinner from '../../../components/common/Spinner/Spinner';
+import { products } from '../../../mock/mockData';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { getMyProfile, getProfile } from '../../../api/profileApi';
@@ -31,11 +33,16 @@ export default function ProfilePage() {
   const { accountname: accountnameByParams } = useParams();
 
   const [selectedTab, setSelectedTab] = useState('list');
-  const [selectedProduct, setSelectedProduct] = useState('');
+  const [selectedProduct, setSelectedProduct] = useState([]);
+  const [selectedPost, setSelectedPost] = useState({});
+
   const [isShowMoreProfile, setIsShowMoreProfile] = useState(false);
   const [isShowMorePost, setIsShowMorePost] = useState(false);
   const [isShowProductDetail, setIsShowProductDetail] = useState(false);
 
+  const [isShowConfirm, setIsShowConfirm] = useState(false);
+  const [confirmType, setConfirmType] = useState({ type: '', object: '' });
+  const [modalType, setModalType] = useState('');
 
   const queryClient = useQueryClient();
 
@@ -96,17 +103,22 @@ export default function ProfilePage() {
 
   const handleClickMoreProfileButton = () => {
     setIsShowMoreProfile(true);
+    setModalType('profile');
   };
 
-  const handleClickMorePostButton = () => {
+  const handleClickMorePostButton = (selectedPost) => {
+    setSelectedPost(selectedPost);
     setIsShowMorePost(true);
+    if (myProfileData.accountname === selectedPost.author.accountname) {
+      setModalType('myPost');
+    } else {
+      setModalType('userPost');
+    }
   };
 
   const handleClickProduct = (productId) => {
-    if (!isShowProductDetail) {
-      const selectedProductInfo = products.filter((product) => product.id === productId);
-      setSelectedProduct(selectedProductInfo);
-    }
+    const selectedProductInfo = products.filter((product) => product.id === productId);
+    setSelectedProduct(selectedProductInfo);
     setIsShowProductDetail(true);
   };
 
@@ -116,6 +128,77 @@ export default function ProfilePage() {
     setIsShowProductDetail(false);
   };
 
+  const handleClickLModalItem = (e) => {
+    if (isShowMoreProfile) {
+      if (e.target.innerText === '로그아웃') {
+        setConfirmType({ type: 'logout' });
+      } else {
+        navigate(`/profile/edit`, { state: myProfileData });
+      }
+    }
+
+    if (isShowProductDetail) {
+      if (e.target.innerText === '삭제') {
+        setConfirmType({ type: 'delete', object: 'product' });
+      } else {
+        navigate(`/product/${selectedProduct[0].id}/edit`);
+      }
+    }
+
+    if (isShowMorePost) {
+      if (e.target.innerText === '삭제') {
+        setConfirmType({ type: 'delete', object: 'post' });
+      } else if (e.target.innerText === '신고하기') {
+        setConfirmType({ type: 'report', object: 'post' });
+      } else {
+        navigate(`/post/${selectedPost.id}/edit`);
+      }
+    }
+
+    setIsShowConfirm(true);
+  };
+
+  const handleClickConfirm = () => {
+    switch (confirmType.object) {
+      case 'product':
+        if (confirmType.type === 'delete') {
+          deleteProductMutation.mutate(selectedProduct[0].id);
+        } else {
+          navigate(`/product/${selectedProduct[0].id}/edit`);
+        }
+        break;
+      case 'post':
+        if (confirmType.type === 'delete') {
+          deletePostMutation.mutate(selectedPost.id);
+        } else if (confirmType.type === 'report') {
+          reportPostMutation.mutate(selectedPost.id);
+        } else {
+          navigate(`/post/${selectedPost.id}/edit`);
+        }
+        break;
+      default:
+        // object가 없는 경우 === 로그아웃
+        localStorage.setItem('token', null);
+        navigate('/main');
+        break;
+    }
+    setIsShowConfirm(false);
+    handleClickCloseModal();
+  };
+
+  // 로딩중일때
+  if (isMyPostLoading || isProfileLoading || isMyProfileLoading) {
+    return (
+      <BasicLayout
+        type={'profile'}
+        onClickLeftButton={() => navigate(-1)}
+        onClickRightButton={handleClickMoreProfileButton}
+      >
+        <Spinner />
+      </BasicLayout>
+    );
+  }
+
   return (
     <BasicLayout
       type={'profile'}
@@ -123,40 +206,51 @@ export default function ProfilePage() {
       onClickRightButton={handleClickMoreProfileButton}
     >
       <ProfilePageWrapper>
-        {(accountnameByParams ? !isUserProfileLoading : !isMyProfileLoading) && (
-          <>
-            <ProfileCard
-              profile={accountnameByParams ? userProfileData.profile : myProfileData.user}
-            />
-            <ProductList products={products} onClick={handleClickProduct} />
-            {posts.length > 0 ? (
-              <>
-                <ViewTabs selectedTab={selectedTab} onClick={handleClickTabButton} />
-                <PostList
-                  selectedTab={selectedTab}
-                  posts={posts}
-                  moreInfo={false}
-                  onClick={handleClickMorePostButton}
-                />
-              </>
-            ) : (
-              <Message>작성된 게시물이 없습니다.</Message>
-            )}
-          </>
-        )}
+        <>
+          <ProfileCard
+            profile={profileData}
+            isMyProfile={profileData.accountname === myProfileData.accountname}
+          />
+          <ProductList products={products} onClick={handleClickProduct} />
+          {myPostData.length > 0 ? (
+            <>
+              <ViewTabs selectedTab={selectedTab} onClick={handleClickTabButton} />
+              <PostList
+                profile={profileData}
+                selectedTab={selectedTab}
+                posts={myPostData}
+                moreInfo={false}
+                onClick={handleClickMorePostButton}
+              />
+            </>
+          ) : (
+            <Message>작성된 게시물이 없습니다.</Message>
+          )}
+        </>
 
         {/* -- BottomSheet */}
-        <BottomSheet isShow={isShowMoreProfile} onClick={handleClickCloseModal}>
-          <ListModal type='profile' />
-        </BottomSheet>
-        <BottomSheet isShow={isShowMorePost} onClick={handleClickCloseModal}>
-          <ListModal type='myPost' />
+        <BottomSheet isShow={isShowMoreProfile || isShowMorePost} onClick={handleClickCloseModal}>
+          <ListModal type={modalType} onClick={handleClickLModalItem} />
         </BottomSheet>
         <BottomSheet isShow={isShowProductDetail} onClick={handleClickCloseModal}>
           <BasicModal>
-            <ProductDetailCard selectedProduct={selectedProduct} />
+            <ProductDetailCard
+              isMyProfile={profileData.accountname === myProfileData.accountname}
+              selectedProduct={selectedProduct}
+              onClick={handleClickLModalItem}
+            />
           </BasicModal>
         </BottomSheet>
+
+        {/* -- Confirm */}
+        {isShowConfirm && (
+          <Confirm
+            type={confirmType.type}
+            object={confirmType.object}
+            setIsShowConfirm={setIsShowConfirm}
+            onClick={handleClickConfirm}
+          />
+        )}
       </ProfilePageWrapper>
     </BasicLayout>
   );

--- a/src/pages/ProfilePage/ProfilePage/ProfilePage.jsx
+++ b/src/pages/ProfilePage/ProfilePage/ProfilePage.jsx
@@ -47,8 +47,9 @@ export default function ProfilePage() {
   const queryClient = useQueryClient();
 
   // 프로필 정보 받기
-  const { data: profileData, isLoading: isProfileLoading } = useQuery('profile', () =>
-    accountnameByParams ? getProfile(accountnameByParams) : getMyProfile(),
+  const { data: profileData, isLoading: isProfileLoading } = useQuery(
+    ['profile', accountnameByParams],
+    () => (accountnameByParams ? getProfile(accountnameByParams) : getMyProfile()),
   );
 
   const { data: myProfileData, isLoading: isMyProfileLoading } = useQuery(

--- a/src/pages/Router.jsx
+++ b/src/pages/Router.jsx
@@ -9,6 +9,8 @@ import SearchPage from './SearchPage/SearchPage';
 import PostPage from './PostPage/PostPage/PostPage';
 import PostUploadPage from './PostPage/PostUploadPage/PostUploadPage';
 import PostEditPage from './PostPage/PostEditPage/PostEditPage';
+import ProductUploadPage from './ProductPage/ProductUploadPage/ProductUploadPage';
+import ProductEditPage from './ProductPage/ProductEditPage/ProductEditPage';
 import ProfilePage from './ProfilePage/ProfilePage/ProfilePage';
 import ProfileEditPage from './ProfilePage/ProfileEditPage/ProfileEditPage';
 import FollowersPage from './ProfilePage/FollowPage/FollowersPage/FollowersPage';
@@ -31,6 +33,8 @@ export default function AppRouter() {
         <Route path='/post/upload' element={<PostUploadPage />} />
         <Route path='/post/:postId' element={<PostPage />} />
         <Route path='/post/:postId/edit' element={<PostEditPage />} />
+        <Route path='/product/upload' element={<ProductUploadPage />} />
+        <Route path='/product/:productId/edit' element={<ProductEditPage />} />
         <Route path='/profile'>
           <Route index element={<ProfilePage />} />
           <Route path='edit' element={<ProfileEditPage />} />

--- a/src/utils/filterPosts.js
+++ b/src/utils/filterPosts.js
@@ -1,7 +1,6 @@
-// TODO: 공간에 따라 포스트 데이터 필터링 기능 추가
-export const filterPosts = (posts) => {
-  const imgInfoArr = posts.map(({ _id, author, image }) => ({
-    id: _id,
+export const filterUserPosts = (posts) => {
+  const imgInfoArr = posts.map(({ id, author, image }) => ({
+    id: id,
     author: author.accountname,
     imgUrl: image,
   }));


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
ProfilePage에서 사용자에 따라 보여지는 모달창을 구분하고, Confirm 컴포넌트와 연결해 기능을 구현했다.

<br><br>

## 🔍 상세 작업 내용
- 프로필 더보기를 눌렀을 경우 [프로필 설정 페이지로 이동 / 로그아웃]이 되게 했다.
- 상품 더보기를 눌렀을 경우 사용자에 따라 [웹사이트보기 / 웹사이트보기 | 삭제 | 수정] 버튼이 보여지게 했다.
- 상품 더보기를 눌렀을 경우 보여지는 버튼에 따른 동작을 구현했다.
- 게시글 더보기를 눌렀을 경우 사용자에 따라 [신고하기 / 삭제 | 수정]이 보여지고, 해당 기능들을 react-query와 연결하여 구현했다.
- url에 내 프로필 accoutname을 파라미터로 포함하고 있어도 유저 프로필이 아닌 내 프로필로 인식하게 했다.

<br><br>

## 💬 참고 사항
- 현재 프로필 페이지에서 보여지는 게시글의 개수는 기본 10개이다. 추후 무한 스크롤링을 하거나 제한을 해둘지 고민해볼 것

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #90 

<br><br>
