### PR TITLE
♻️ refactor: PostList 컴포넌트 재사용성을 위해 props 값 수정

### DIFF
--- a/src/components/Profile/PostList/PostList.jsx
+++ b/src/components/Profile/PostList/PostList.jsx
@@ -5,13 +5,13 @@ import UserSimpleInfo from '../../common/UserSimpleInfo/UserSimpleInfo/UserSimpl
 import { PostCardList, PostListWrapper } from './PostListStyle';
 import { filterUserPosts } from '../../../utils/filterPosts';
 
-export default function PostList({ selectedTab, profile, posts, moreInfo, onClick }) {
+export default function PostList({ selectedTab, posts, moreInfo, onClick }) {
   const layout = {
     list: (
       <PostCardList>
         {posts.map((item) => (
           <li key={item.id}>
-            <UserSimpleInfo profile={profile} type={'more'} onClick={() => onClick(item)} />
+            <UserSimpleInfo profile={item.author} type={'more'} onClick={() => onClick(item)} />
             <PostCard data={item} moreInfo={moreInfo} />
           </li>
         ))}

--- a/src/pages/ProfilePage/ProfilePage/ProfilePage.jsx
+++ b/src/pages/ProfilePage/ProfilePage/ProfilePage.jsx
@@ -217,7 +217,6 @@ export default function ProfilePage() {
             <>
               <ViewTabs selectedTab={selectedTab} onClick={handleClickTabButton} />
               <PostList
-                profile={profileData}
                 selectedTab={selectedTab}
                 posts={myPostData}
                 moreInfo={false}


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
PostList 컴포넌트 재사용성을 위해 props 값을 수정했다.

<br><br>

## 🔍 상세 작업 내용
PostList에 있는 UserSimpleInfo에 사용되는 현재 프로필 데이터가 필요하다 생각하여 ProfilePage에서 PostList로 props로 프로필 정보를 전달해주었다. 이를 PostList에 있는 게시물 데이터에서 작성자 정보를 전달할 수 있으므로 PostList에 props를 전달해주지 않아도 컴포넌트 내에서 해결할 수 있었다.

<br><br>

## 💬 참고 사항
<!-- 참고할 만한 사항이 있다면 작성해 주세요. -->

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #100 

<br><br>
