### PR TITLE
🐛 fix: 게시글 상세 페이지의 myprofile을 찾지 못하는 문제 해결

### DIFF
--- a/src/pages/PostPage/PostPage/PostPage.jsx
+++ b/src/pages/PostPage/PostPage/PostPage.jsx
@@ -6,7 +6,7 @@ import ListModal from '../../../components/common/BottomSheet/ListModal';
 import PostCard from '../../../components/common/Card/PostCard/PostCard';
 import Confirm from '../../../components/common/Confirm/Confirm';
 import { PostPageWrapper } from './PostPageStyle';
-import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from 'react-query';
+import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { deletePost, getPostDetail, reportPost } from '../../../api/postApi';
 import { getMyProfile } from '../../../api/profileApi';
 import { useRecoilState } from 'recoil';
@@ -69,7 +69,7 @@ export default function PostPage() {
     () => getMyProfile(),
     {
       onSuccess: (data) => {
-        setMyProfile(data.user);
+        setMyProfile(data);
       },
       onError: (error) => {
         console.log(error);
@@ -110,7 +110,7 @@ export default function PostPage() {
 
   //댓글 신고하기
   const reportCommentMutation = useMutation(reportComment, {
-    onSuccess(data) {
+    onSuccess() {
       alert(`해당 댓글을 신고했습니다.`);
     },
     onError(error) {
@@ -206,12 +206,12 @@ export default function PostPage() {
         <BasicLayout
           type='post'
           isNonNav
-          title={postData.post.author.username}
+          title={postData?.post.author.username}
           onClickLeftButton={handleClickLeftButton}
           onClickRightButton={handleClickRightButton}
         >
           <PostPageWrapper>
-            <PostCard data={postData.post} moreInfo />
+            <PostCard data={postData?.post} moreInfo />
             <CommentSection
               data={comments}
               myProfile={myProfile}


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
<!--수정/추가한 작업 내용을 설명해 주세요.-->
프로필 정보 불러오기 변수명을 수정하여 오류를 해결했다.

<br><br>

## 🔍 상세 작업 내용
<!-- 작업한 상세 내용을 설명해 주세요.-->
api호출 함수내에서 리턴값이 data.user로 변경되었는데 확인하지 못해 setMyProfile의 인자로 data.user를 넣어 발생한 문제로 데이터로 넣는 값을 data로 변경하여 문제를 해결했다.

<br><br>

## 💬 참고 사항
<!-- 참고할 만한 사항이 있다면 작성해 주세요. -->

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #105 

<br><br>
