### PR TITLE
✨ feat: 검색 API 연동 및 추가 기능 구현

### DIFF
--- a/src/api/searchApi.js
+++ b/src/api/searchApi.js
@@ -1,0 +1,10 @@
+import { accessInstance } from './axiosInstance';
+
+export const getSearchResult = async (keyword) => {
+  try {
+    const response = await accessInstance.get(`/user/searchuser/?keyword=${keyword}`);
+    return response.data;
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/components/common/UserSimpleInfo/UserSimpleInfo/UserSimpleInfo.jsx
+++ b/src/components/common/UserSimpleInfo/UserSimpleInfo/UserSimpleInfo.jsx
@@ -12,7 +12,7 @@ import Button from '../../Button/Button/Button';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
-export default function UserSimpleInfo({ profile, isLink = false, type, onClick }) {
+export default function UserSimpleInfo({ profile, isLink = false, type, onClick, inputValue }) {
   const [isfollow, setIsFollow] = useState(false);
   const [error, setError] = useState(false);
   const handleClickFollow = () => {
@@ -33,7 +33,26 @@ export default function UserSimpleInfo({ profile, isLink = false, type, onClick 
               <img src={basicProfileImage} alt='기본 프로필 이미지' />
             )}
             <UserNameBox>
-              <UserName>{profile.username}</UserName>
+              <UserName>
+                {inputValue ? (
+                  <>
+                    {profile.username.split(inputValue).map((part, index) =>
+                      index === 0 ? (
+                        part
+                      ) : (
+                        <>
+                          <span className='highlight' key={index}>
+                            {inputValue}
+                          </span>
+                          {part}
+                        </>
+                      ),
+                    )}
+                  </>
+                ) : (
+                  profile.username
+                )}
+              </UserName>
               <AccountName>@ {profile.accountname}</AccountName>
             </UserNameBox>
           </Link>

--- a/src/components/common/UserSimpleInfo/UserSimpleInfo/UserSimpleInfo.jsx
+++ b/src/components/common/UserSimpleInfo/UserSimpleInfo/UserSimpleInfo.jsx
@@ -14,8 +14,12 @@ import { Link } from 'react-router-dom';
 
 export default function UserSimpleInfo({ profile, isLink = false, type, onClick }) {
   const [isfollow, setIsFollow] = useState(false);
+  const [error, setError] = useState(false);
   const handleClickFollow = () => {
     setIsFollow(!isfollow);
+  };
+  const handleImageError = () => {
+    setError(true);
   };
 
   return (
@@ -23,7 +27,11 @@ export default function UserSimpleInfo({ profile, isLink = false, type, onClick 
       <UserInfoBox isLink={isLink}>
         {isLink ? (
           <Link to={'/profile/' + profile.accountname}>
-            <img src={profile.image || basicProfileImage} alt='유저 프로필 이미지' />
+            {!error ? (
+              <img src={profile.image} alt='유저 프로필 이미지' onError={handleImageError} />
+            ) : (
+              <img src={basicProfileImage} alt='기본 프로필 이미지' />
+            )}
             <UserNameBox>
               <UserName>{profile.username}</UserName>
               <AccountName>@ {profile.accountname}</AccountName>
@@ -31,7 +39,11 @@ export default function UserSimpleInfo({ profile, isLink = false, type, onClick 
           </Link>
         ) : (
           <>
-            <img src={profile.image || basicProfileImage} alt='유저 프로필 이미지' />
+            {!error ? (
+              <img src={profile.image} alt='유저 프로필 이미지' onError={handleImageError} />
+            ) : (
+              <img src={basicProfileImage} alt='기본 프로필 이미지' />
+            )}
             <UserNameBox>
               <UserName>{profile.username}</UserName>
               <AccountName>@ {profile.accountname}</AccountName>

--- a/src/components/common/UserSimpleInfo/UserSimpleInfo/UserSimpleStyle.jsx
+++ b/src/components/common/UserSimpleInfo/UserSimpleInfo/UserSimpleStyle.jsx
@@ -40,6 +40,11 @@ const UserName = styled.span`
   font-size: ${({ theme }) => theme.fontSize.sm};
   font-weight: 500;
   margin-bottom: 6px;
+
+  .highlight {
+    color: ${({ theme }) => theme.colors.mainCoral};
+    font-weight: 600;
+  }
 `;
 
 const AccountName = styled.span`

--- a/src/hooks/useDebounce.js
+++ b/src/hooks/useDebounce.js
@@ -1,5 +1,4 @@
 import { useEffect, useState } from 'react';
-import Skeleton from '../components/common/UserSimpleInfo/Skeleton/Skeleton';
 
 const useDebounce = (value, delay) => {
   const [debouncedValue, setDebouncedValue] = useState(value);
@@ -14,7 +13,11 @@ const useDebounce = (value, delay) => {
     }; //value 변경 시점에 clearTimeout을 해줘야함.
   }, [value, delay]);
 
-  return debouncedValue;
+  function cancel() {
+    setDebouncedValue(value);
+  }
+
+  return { debouncedValue, cancel };
 };
 
 export default useDebounce;

--- a/src/hooks/useDebounce.js
+++ b/src/hooks/useDebounce.js
@@ -1,0 +1,20 @@
+import { useEffect, useState } from 'react';
+import Skeleton from '../components/common/UserSimpleInfo/Skeleton/Skeleton';
+
+const useDebounce = (value, delay) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    }; //value 변경 시점에 clearTimeout을 해줘야함.
+  }, [value, delay]);
+
+  return debouncedValue;
+};
+
+export default useDebounce;

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -25,7 +25,7 @@ const Message = styled.p`
 export default function Search({ onClickLeftButton }) {
   const [inputValue, setInputValue] = useState('');
 
-  const { data: searchResult, isLoading } = useQuery(
+  const { data: searchResult, isFetching } = useQuery(
     ['searchUser', inputValue],
     () => getSearchResult(inputValue),
     {
@@ -59,15 +59,17 @@ export default function Search({ onClickLeftButton }) {
               ))}
             </>
           ) : (
-            <>
-              {Array(10)
-                .fill()
-                .map((_, idx) => (
-                  <li key={idx}>
-                    <Skeleton />
-                  </li>
-                ))}
-            </>
+            isFetching && (
+              <>
+                {Array(10)
+                  .fill()
+                  .map((_, idx) => (
+                    <li key={idx}>
+                      <Skeleton />
+                    </li>
+                  ))}
+              </>
+            )
           ))}
       </UserInfoList>
     </BasicLayout>

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -25,7 +25,7 @@ const Message = styled.p`
 
 export default function Search({ onClickLeftButton }) {
   const [inputValue, setInputValue] = useState('');
-  const debouncedSearchUser = useDebounce(inputValue, 500);
+  const { debouncedValue: debouncedSearchUser, cancel } = useDebounce(inputValue, 500);
 
   const { data: searchResult, isFetching } = useQuery(
     ['searchUser', debouncedSearchUser],
@@ -41,6 +41,9 @@ export default function Search({ onClickLeftButton }) {
 
   const handleChangeInput = (e) => {
     setInputValue(e.target.value);
+    if (inputValue === '') {
+      cancel(); // inputValue를 모두 지웠을 때 debounce값도 초기화
+    }
   };
 
   return (
@@ -51,15 +54,7 @@ export default function Search({ onClickLeftButton }) {
       onChange={handleChangeInput}
     >
       <UserInfoList>
-        {inputValue && debouncedSearchUser && searchResult?.length >= 1 ? (
-          <>
-            {searchResult.map((profile) => (
-              <li key={profile._id}>
-                <UserSimpleInfo profile={profile} isLink={true} />
-              </li>
-            ))}
-          </>
-        ) : isFetching ? (
+        {isFetching ? (
           <>
             {Array(10)
               .fill()
@@ -69,6 +64,12 @@ export default function Search({ onClickLeftButton }) {
                 </li>
               ))}
           </>
+        ) : inputValue && debouncedSearchUser && searchResult?.length > 0 ? (
+          searchResult.map((user) => (
+            <li key={user._id}>
+              <UserSimpleInfo profile={user} isLink={true} />
+            </li>
+          ))
         ) : (
           inputValue && <Message>일치하는 유저가 없습니다.</Message>
         )}

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -1,8 +1,9 @@
 import React, { useState } from 'react';
 import BasicLayout from '../../layout/BasicLayout';
 import UserSimpleInfo from '../../components/common/UserSimpleInfo/UserSimpleInfo/UserSimpleInfo';
-import { profile } from '../../mock/mockData';
 import styled from 'styled-components';
+import { useQuery } from 'react-query';
+import { getSearchResult } from '../../api/searchApi';
 import Skeleton from '../../components/common/UserSimpleInfo/Skeleton/Skeleton';
 
 const UserInfoList = styled.ul`
@@ -13,29 +14,45 @@ const UserInfoList = styled.ul`
   }
 `;
 
+const Message = styled.p`
+  font-weight: 500;
+  font-size: ${({ theme }) => theme.fontSize.base};
+  color: ${({ theme }) => theme.colors.gray200};
+  padding-top: 52px;
+  text-align: center;
+`;
+
 export default function Search({ onClickLeftButton }) {
-  const [search, setSearch] = useState('');
+  const [inputValue, setInputValue] = useState('');
+
+  const { data: searchResult, isLoading } = useQuery(
+    ['searchUser', inputValue],
+    () => getSearchResult(inputValue),
+    {
+      enabled: !!inputValue,
+      select: (result) =>
+        result.filter((user) => {
+          return user.username.includes(inputValue);
+        }),
+    },
+  );
 
   const handleChangeInput = (e) => {
-    setSearch(e.target.value);
+    setInputValue(e.target.value);
   };
-
-  const filterProfile = profile.filter((p) => {
-    return p.username.toLowerCase().includes(search.toLowerCase());
-  });
 
   return (
     <BasicLayout
       type='search'
       onClickLeftButton={onClickLeftButton}
-      value={search}
+      value={inputValue}
       onChange={handleChangeInput}
     >
       <UserInfoList>
-        {search &&
-          (filterProfile.length >= 1 ? (
+        {inputValue &&
+          (searchResult?.length >= 1 ? (
             <>
-              {filterProfile.map((profile) => (
+              {searchResult.map((profile) => (
                 <li key={profile._id}>
                   <UserSimpleInfo profile={profile} isLink={true} />
                 </li>
@@ -43,11 +60,13 @@ export default function Search({ onClickLeftButton }) {
             </>
           ) : (
             <>
-              {profile.map((profile) => (
-                <li key={profile._id}>
-                  <Skeleton />
-                </li>
-              ))}
+              {Array(10)
+                .fill()
+                .map((_, idx) => (
+                  <li key={idx}>
+                    <Skeleton />
+                  </li>
+                ))}
             </>
           ))}
       </UserInfoList>

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -65,6 +65,10 @@ export default function Search({ onClickLeftButton }) {
     }
   }, []);
 
+  // const handleChangeTextColor = () => {
+
+  // }
+
   return (
     <BasicLayout
       type='search'
@@ -92,7 +96,7 @@ export default function Search({ onClickLeftButton }) {
         ) : inputValue && debouncedSearchUser && searchResult?.length > 0 ? (
           searchResult.map((user) => (
             <li key={user._id} onClick={() => handleSaveSearchResult(user)}>
-              <UserSimpleInfo profile={user} isLink={true} />
+              <UserSimpleInfo profile={user} isLink={true} inputValue={inputValue} />
             </li>
           ))
         ) : (

--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -65,10 +65,6 @@ export default function Search({ onClickLeftButton }) {
     }
   }, []);
 
-  // const handleChangeTextColor = () => {
-
-  // }
-
   return (
     <BasicLayout
       type='search'


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
<!--수정/추가한 작업 내용을 설명해 주세요.-->
검색 API 연동 및 추가 기능을 구현했다.
<br><br>

## 🔍 상세 작업 내용
<!-- 작업한 상세 내용을 설명해 주세요.-->
- [x] 검색 API 연동하여 UserSearchApi에서 User를 필터링하여 보여준다.
- [x] 검색 결과가 없을 때 Skeleton UI를 보여주는 대신 isFetching 상태일 때 Skeleton UI를 보여주도록 수정했다.
- [x] debounce를 추가하여 마지막 입력 후 0.5초 이후에 검색 결과가 보여지도록 수정했다.
- [x] 검색 후 inputValue를 모두 지우고 다시 검색했을 때 이전 결과가 보이는 버그를 수정했다.
- [x] 최근 검색 기록을 LocalStorage에 저장한 후 아무것도 입력 안했을 때 보여줬다.
- [x] 프로필 이미지 없을 때 대체텍스트 대신 기본 프로필 이미지로 변경하도록 수정했다.
- [x] 검색하는 단어와 일치하는 유저명 색을 변경하여 하이라이트 해주는 기능을 추가했다.
<br><br>

## 💬 참고 사항
<!-- 참고할 만한 사항이 있다면 작성해 주세요. -->
- 아무것도 검색 안했을 때 최근 검색했던 프로필 목록을 보여준다.
![image](https://github.com/FRONTENDSCHOOL5/final-14-BangKKuseok/assets/64193469/3bc015e8-8c95-4f69-8306-f0c0aa509ea0)
- 검색했을 때 일치하는 단어에 하이라이트를 해준다.
![image](https://github.com/FRONTENDSCHOOL5/final-14-BangKKuseok/assets/64193469/3c802965-8e8d-484b-98e8-fd07c5ef95d0)

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #117

<br><br>
