### PR TITLE
🐛 fix: 프로필 수정 시 프로필 페이지에서 이전 데이터를 요청하는 오류 해결

### DIFF
--- a/src/pages/ProfilePage/ProfileEditPage/ProfileEditPage.jsx
+++ b/src/pages/ProfilePage/ProfileEditPage/ProfileEditPage.jsx
@@ -3,7 +3,7 @@ import BasicLayout from '../../../layout/BasicLayout';
 import SetUserProfileForm from '../../../components/LoginSignUp/SetUserProfile/SetUserProfileForm';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { updateProfile } from '../../../api/profileApi';
-import { useMutation } from 'react-query';
+import { useMutation, useQueryClient } from 'react-query';
 
 export default function ProfileEditPage() {
   const [isButtonActive, setIsButtonActive] = useState(false);
@@ -18,9 +18,15 @@ export default function ProfileEditPage() {
   const location = useLocation();
   const myData = location.state;
 
-  const updateProfileMutation = useMutation((formData) => updateProfile(formData), {
+  const queryClient = useQueryClient();
+
+  const updateProfileMutation = useMutation(updateProfile, {
     onSuccess: () => {
       navigate('/profile');
+    },
+    onMutate: () => {
+      // 이전 데이터를 캐시에서 제거
+      queryClient.removeQueries('myProfile');
     },
     onError: () => {
       console.error('프로필 수정 실패');
@@ -28,14 +34,7 @@ export default function ProfileEditPage() {
   });
 
   const handleClickSaveButton = () => {
-    updateProfileMutation.mutate({
-      user: {
-        username: newProfile.username,
-        accountname: newProfile.accountname,
-        intro: newProfile.intro,
-        image: newProfile.image,
-      },
-    });
+    updateProfileMutation.mutate({ user: { ...newProfile } });
   };
 
   return (


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
프로필 수정 페이지에서 계정 ID 수정 시 프로필 페이지로 이동했을 때 이전 데이터를 요청하는 오류를 해결했다.

<br><br>

## 🔍 상세 작업 내용
- react query에서 onMutate 메서드를 사용하여 mutate 되기 전에 이전 캐시 값을 제거했다.

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #121 

<br><br>
