### PR TITLE
🐛 fix: 검색 결과 목록이 7개 이하일 때 더보기 버튼 안보이게 수정

### DIFF
--- a/src/pages/SearchPage/SearchPage.jsx
+++ b/src/pages/SearchPage/SearchPage.jsx
@@ -51,13 +51,13 @@ export default function Search({ onClickLeftButton }) {
     {
       enabled: !!debouncedSearchUser,
       select: (result) =>
-        result
-          .filter((user) => {
-            return user.username.includes(debouncedSearchUser);
-          })
-          .slice(0, view * 7),
+        result.filter((user) => {
+          return user.username.includes(debouncedSearchUser);
+        }),
     },
   );
+
+  const paginatedSearchResult = searchResult?.slice(0, view * 7);
 
   const handleChangeInput = (e) => {
     setInputValue(e.target.value);
@@ -108,13 +108,15 @@ export default function Search({ onClickLeftButton }) {
           </>
         ) : inputValue && debouncedSearchUser && searchResult?.length > 0 ? (
           <>
-            {searchResult.map((user) => (
+            {paginatedSearchResult.map((user) => (
               <li key={user._id} onClick={() => handleSaveSearchResult(user)}>
                 <UserSimpleInfo profile={user} isLink={true} inputValue={inputValue} />
               </li>
             ))}
-            {(searchResult?.length % view) * 7 < 7 && (
-              <MoreButton onClick={handleClickMore}>검색결과 더보기</MoreButton>
+            {paginatedSearchResult?.length % (view * 7) < 7 && searchResult?.length > 7 && (
+              <MoreButton type='button' onClick={handleClickMore}>
+                검색결과 더보기
+              </MoreButton>
             )}
           </>
         ) : (


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
<!--수정/추가한 작업 내용을 설명해 주세요.-->
검색 결과 목록이 7개 이하일 때도 더보기 버튼이 보이던 것을 안보이게 수정했다.
<br><br>

## 🔍 상세 작업 내용
<!-- 작업한 상세 내용을 설명해 주세요.-->
useQuery의 select 안에서 slice까지 모두 처리해서 전체 검색 목록의 수를 불러오지 못해서 slice를 밖으로 빼 전체 검색 목록의 개수가 7개 이하일 때 더보기 버튼을 안보이게 하는 로직을 추가하였다.
<br><br>

## 💬 참고 사항
<!-- 참고할 만한 사항이 있다면 작성해 주세요. -->
- 7개 이하일 때 
![image](https://github.com/FRONTENDSCHOOL5/final-14-BangKKuseok/assets/64193469/15d2e734-6afc-4cef-9c3e-3bd2d3576027)
- 7개 초과일 때
![image](https://github.com/FRONTENDSCHOOL5/final-14-BangKKuseok/assets/64193469/ec6d34bf-d714-4e31-9e0b-300e53ff0ccb)

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #132

<br><br>
