### PR TITLE
🐛 fix: 로그아웃 후 재 로그인 시 기존 데이터가 보이는 오류 해결

### DIFF
--- a/src/api/axiosInstance.js
+++ b/src/api/axiosInstance.js
@@ -19,6 +19,16 @@ export const accessInstance = axios.create({
   baseURL: URL,
   headers: {
     'Content-Type': 'application/json',
-    Authorization: `Bearer ${localStorage.getItem('token')}`,
   },
+});
+
+accessInstance.interceptors.request.use((config) => {
+  if (!config.headers.Authorization) {
+    config.headers = {
+      ...config.headers,
+      Authorization: `Bearer ${localStorage.getItem('token')}`,
+    };
+  }
+
+  return config;
 });

--- a/src/pages/ProfilePage/ProfilePage/ProfilePage.jsx
+++ b/src/pages/ProfilePage/ProfilePage/ProfilePage.jsx
@@ -182,7 +182,8 @@ export default function ProfilePage() {
         break;
       default:
         // object가 없는 경우 === 로그아웃
-        localStorage.setItem('token', null);
+        queryClient.removeQueries('myProfile');
+        localStorage.removeItem('token');
         navigate('/main');
         break;
     }


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
로그아웃 후 재 로그인 시 기존 데이터가 보이는 오류를 해결했다.

<br><br>

## 🔍 상세 작업 내용
axios 인스턴스에 Authorization의 값이 고정되어 다시 재 로그인을 했을 때 기존 데이터가 보이는 현상이 발생했다.
따라서 axios의 interceptors를 사용해서 axios 요청 전에 Authorization을 세팅할 수 있게 했다.

<br><br>

## 💬 참고 사항
[Axios Docs](https://axios-http.com/docs/interceptors)

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #140 

<br><br>
