### PR TITLE
✨ feat: 프로필 수정에서 이미 가입된 ID를 입력할 경우 경고메시지를 출력하는 기능 구현

### DIFF
--- a/src/api/profileApi.js
+++ b/src/api/profileApi.js
@@ -19,10 +19,6 @@ export const getMyProfile = async () => {
 };
 
 export const updateProfile = async (formData) => {
-  try {
-    const response = await accessInstance.put(`/user`, formData);
-    return response.data;
-  } catch (error) {
-    console.error(error);
-  }
+  const response = await accessInstance.put(`/user`, formData);
+  return response.data;
 };

--- a/src/pages/ProfilePage/ProfileEditPage/ProfileEditPage.jsx
+++ b/src/pages/ProfilePage/ProfileEditPage/ProfileEditPage.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import BasicLayout from '../../../layout/BasicLayout';
 import SetUserProfileForm from '../../../components/LoginSignUp/SetUserProfile/SetUserProfileForm';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -6,6 +6,7 @@ import { updateProfile } from '../../../api/profileApi';
 import { useMutation, useQueryClient } from 'react-query';
 
 export default function ProfileEditPage() {
+  const [isAlreadyIdMsg, setIsAlreadyIdMsg] = useState('');
   const [isButtonActive, setIsButtonActive] = useState(false);
   const [newProfile, setNewProfile] = useState({
     username: '',
@@ -28,14 +29,18 @@ export default function ProfileEditPage() {
       // 이전 데이터를 캐시에서 제거
       queryClient.removeQueries('myProfile');
     },
-    onError: () => {
-      console.error('프로필 수정 실패');
+    onError: (error) => {
+      setIsAlreadyIdMsg(error.response.data.message);
     },
   });
 
   const handleClickSaveButton = () => {
     updateProfileMutation.mutate({ user: { ...newProfile } });
   };
+
+  useEffect(() => {
+    setIsAlreadyIdMsg('');
+  }, [newProfile.accountname]);
 
   return (
     <BasicLayout
@@ -50,6 +55,7 @@ export default function ProfileEditPage() {
         myData={myData}
         setIsButtonActive={setIsButtonActive}
         setData={setNewProfile}
+        message={isAlreadyIdMsg}
       />
     </BasicLayout>
   );


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
프로필 수정에서 이미 가입된 ID를 입력할 경우, api에서 데이터를 불러와서 에러메시지를 SetUserProfileForm에 전달하였다.

<br><br>

## 🔍 상세 작업 내용
- ProfileApi.js의 updateProfile에서 api 불러오는 부분 수정
- onError 부분의 메시지를 ProfileForm에 전달

<br><br>

## 💬 참고 사항
- error콘솔 출력 내용, 따라서 error.response.data.message를 SetUserProfileForm에 메시지로 전달해줘야함
![image](https://github.com/FRONTENDSCHOOL5/final-14-BangKKuseok/assets/111286497/487f0c2e-9e0f-41fa-a6b4-91ac40b6c241)

- feature/#137에서 올릴 작업내용이 남아있어서 브랜치 삭제는 추후에 진행


<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #146 

<br><br>
