### PR TITLE
🐛 fix: 피드, 팔로워, 팔로잉 페이지 무한 스크롤 기능 오류 해결

### DIFF
--- a/src/pages/FeedPage/FeedPage.jsx
+++ b/src/pages/FeedPage/FeedPage.jsx
@@ -122,7 +122,7 @@ export default function FeedPage() {
               onClick={handleClickMorePostButton}
             />
           </FeedPageWrapper>
-          <div ref={observerRef}></div>
+          <div ref={observerRef} style={{ minHeight: '1px' }}></div>
           {isShow && (
             <BottomSheet isShow={isShow} onClick={handleClickModalOpen}>
               <ListModal type='userPost' onClick={handleClickListItem} />

--- a/src/pages/ProfilePage/FollowPage/FollowersPage/FollowersPage.jsx
+++ b/src/pages/ProfilePage/FollowPage/FollowersPage/FollowersPage.jsx
@@ -99,7 +99,9 @@ export default function FollowersPage() {
             </FollowerList>
           </>
         )}
-        <div ref={observerRef}></div>
+        <div ref={observerRef} style={{ minHeight: '1px' }}>
+          {(isLoading || isFetching) && <Spinner />}
+        </div>
       </FollowerWrapper>
     </BasicLayout>
   );

--- a/src/pages/ProfilePage/FollowPage/FollowingsPage/FollowingsPage.jsx
+++ b/src/pages/ProfilePage/FollowPage/FollowingsPage/FollowingsPage.jsx
@@ -74,10 +74,6 @@ export default function FollowingsPage() {
     deleteUnFollowMutation.mutate(accountname);
   };
 
-  if (isLoading || isFetching) {
-    return <Spinner />;
-  }
-
   return (
     <BasicLayout type='follow' title='팔로잉' onClickLeftButton={handleClickBackButton}>
       <FollowerWrapper>
@@ -96,7 +92,9 @@ export default function FollowingsPage() {
             ))}
           </FollowerList>
         </>
-        <div ref={observerRef}></div>
+        <div ref={observerRef} style={{ minHeight: '1px' }}>
+          {(isLoading || isFetching) && <Spinner />}
+        </div>
       </FollowerWrapper>
     </BasicLayout>
   );


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
피드, 팔로워, 팔로잉 페이지에서 스크롤 시 추가 데이터를 받아오지 않는 오류가 발생했다.

<br><br>

## 🔍 상세 작업 내용
- observer가 타겟팅한 대상에 높이값을 지정한다.
- 팔로워, 팔로잉 페이지의 Spinner 위치 조절
 - 팔로워, 팔로잉 페이지의 경우 isLoading일 때 Spinner 컴포넌트가 동작하게 되는데, Spinner 컴포넌트의 높이가 100vh이기 때문에 로딩중일 때 observer는 타겟팅 대상을 잃어버린다. 
 - 따라서 Spinner의 위치를 타겟팅 대상 안에 넣어준다.

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #176 

<br><br>
