### PR TITLE
♻️ refactor: 게시글 등록 시 드래그해도 상품 태그 가능하도록 수정

### DIFF
--- a/src/components/PostUpload/PostProductTag/PostProductTag.jsx
+++ b/src/components/PostUpload/PostProductTag/PostProductTag.jsx
@@ -7,12 +7,12 @@ import BasicModal from '../../common/BottomSheet/BasicModal';
 import ModalProductList from '../ModalProductList/ModalProductList';
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import {
-  bubbleLocAtom,
   mouseLocAtom,
   selectedProductsAtom,
   userProductsAtom,
 } from '../../../atoms/post';
 import ProductTag from '../ProductTag/ProductTag';
+import useBubbleLocation from '../../../hooks/useBubbleLocation';
 import { MOUSEBENCHMARK } from '../../../constants/common';
 
 export default function PostProductTag({ postedImg, setIsBtnActive }) {
@@ -50,26 +50,7 @@ export default function PostProductTag({ postedImg, setIsBtnActive }) {
     }
   };
 
-  //마우스 위치에 따른 말풍선 위치
-  useEffect(() => {
-    let eLeft = 50;
-    if (mouseLoc.x > 67) {
-      eLeft = 51.5 + (mouseLoc.x - 68) * 1.63;
-    } else if (mouseLoc.x < 33) {
-      eLeft = 6 + (mouseLoc.x - 6) * 1.59;
-    } else {
-      eLeft = 50;
-    }
-    if (mouseLoc.y < 28) {
-      eLeft = eLeft - 2.5;
-    }
-    setBubbleLoc({
-      x: mouseLoc.x < 33 ? 33 : mouseLoc.x > 67 ? 67 : mouseLoc.x,
-      y: mouseLoc.y > 28 ? mouseLoc.y - 7 : mouseLoc.y + 27,
-      bubbleUp: mouseLoc.y > 28,
-      edgeLeft: eLeft,
-    });
-  }, [mouseLoc, setBubbleLoc]);
+  useBubbleLocation();
 
   useEffect(() => {
     if (tagStep === '상품목록 확인' && selectedItems.length === 0 && !isShow) {

--- a/src/components/PostUpload/PostProductTag/PostProductTag.jsx
+++ b/src/components/PostUpload/PostProductTag/PostProductTag.jsx
@@ -18,15 +18,8 @@ import { MOUSEBENCHMARK } from '../../../constants/common';
 export default function PostProductTag({ postedImg, setIsBtnActive }) {
   //태그추가 단계 : 클릭 유도 / 상품목록 확인 / 태그와 버블 / 상품태그 추가
   const [tagStep, setTagStep] = useState('클릭 유도');
-
   const [isBubbleShow, setIsBubbleShow] = useState(true);
   const [isShow, setIsShow] = useState(false);
-
-  //마우스, 말풍선 위칫값
-  const [mouseLoc, setMouseLoc] = useRecoilState(mouseLocAtom);
-  const setBubbleLoc = useSetRecoilState(bubbleLocAtom);
-
-  //선택된 데이터
   const selectedItems = useRecoilValue(selectedProductsAtom);
   const userItems = useRecoilValue(userProductsAtom);
   const { xLeftBenchmark, xRightBenchmark, yLeftBenchmark, yRightBenchmark } = MOUSEBENCHMARK;
@@ -37,11 +30,9 @@ export default function PostProductTag({ postedImg, setIsBtnActive }) {
     }
   }, []);
 
-  //이미지 위 클릭하면
   const handleClickImg = (e) => {
     //1.'클릭 유도'일때
     if ((tagStep === '클릭 유도' || tagStep === '상품태그 추가') && e.target === e.currentTarget) {
-      // 마우스 위치 지정
       const x = Math.floor((e.nativeEvent.offsetX / e.currentTarget.offsetWidth) * 100);
       const y = Math.floor((e.nativeEvent.offsetY / e.currentTarget.offsetWidth) * 100);
       setMouseLoc({
@@ -49,7 +40,6 @@ export default function PostProductTag({ postedImg, setIsBtnActive }) {
         y: y < yLeftBenchmark ? yLeftBenchmark : y > yRightBenchmark ? yRightBenchmark : y,
       });
 
-      //바텀시트 열고 tagStep 바꾸기
       setIsShow(true);
       setTagStep('상품목록 확인');
 
@@ -81,14 +71,12 @@ export default function PostProductTag({ postedImg, setIsBtnActive }) {
     });
   }, [mouseLoc, setBubbleLoc]);
 
-  //상품선택 안하고 모달 닫았을 때 돌아가기
   useEffect(() => {
     if (tagStep === '상품목록 확인' && selectedItems.length === 0 && !isShow) {
       setTagStep('클릭 유도');
     }
   }, [isShow, selectedItems, setIsBtnActive, tagStep]);
 
-  //선택상품이 있거나 아예 판매상품이 없을때 다음단계로 넘어갈 수 있다
   useEffect(() => {
     if (userItems.length === 0 || selectedItems.length >= 1) {
       setIsBtnActive(true);
@@ -97,7 +85,6 @@ export default function PostProductTag({ postedImg, setIsBtnActive }) {
     }
   }, [selectedItems, setIsBtnActive, userItems]);
 
-  //바텀시트 여닫기
   const handleClickModalOpen = () => {
     setIsShow((prev) => !prev);
   };

--- a/src/components/PostUpload/PostProductTag/PostProductTag.jsx
+++ b/src/components/PostUpload/PostProductTag/PostProductTag.jsx
@@ -5,8 +5,9 @@ import ProductBubble from '../ProductBubble/ProductBubble';
 import BottomSheet from '../../common/BottomSheet/BottomSheet';
 import BasicModal from '../../common/BottomSheet/BasicModal';
 import ModalProductList from '../ModalProductList/ModalProductList';
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import {
+  canSelectProductSelector,
   mouseLocAtom,
   selectedProductsAtom,
   userProductsAtom,
@@ -22,6 +23,7 @@ export default function PostProductTag({ postedImg, setIsBtnActive }) {
   const [isShow, setIsShow] = useState(false);
   const selectedItems = useRecoilValue(selectedProductsAtom);
   const userItems = useRecoilValue(userProductsAtom);
+  const canSeletedItems = useRecoilValue(canSelectProductSelector);
   const { xLeftBenchmark, xRightBenchmark, yLeftBenchmark, yRightBenchmark } = MOUSEBENCHMARK;
 
   useEffect(() => {
@@ -44,7 +46,7 @@ export default function PostProductTag({ postedImg, setIsBtnActive }) {
       setTagStep('상품목록 확인');
 
       //2.'태그와 버블'일때
-    } else if (tagStep === '태그와 버블') {
+    } else if (tagStep === '태그와 버블' && canSeletedItems.length > 0) {
       setIsBubbleShow(false);
       setTagStep('상품태그 추가');
     }
@@ -53,8 +55,12 @@ export default function PostProductTag({ postedImg, setIsBtnActive }) {
   useBubbleLocation();
 
   useEffect(() => {
-    if (tagStep === '상품목록 확인' && selectedItems.length === 0 && !isShow) {
-      setTagStep('클릭 유도');
+    if (tagStep === '상품목록 확인' && !isShow) {
+      if (selectedItems.length === 0) {
+        setTagStep('클릭 유도');
+      } else {
+        setTagStep('태그와 버블');
+      }
     }
   }, [isShow, selectedItems, setIsBtnActive, tagStep]);
 
@@ -75,7 +81,9 @@ export default function PostProductTag({ postedImg, setIsBtnActive }) {
       <PostProductTagWrapper>
         <ImgBox>
           <img src={postedImg} alt='게시글 이미지' />
-          <TagBox onClick={handleClickImg}>
+          <TagBox
+            isPointer={tagStep === '클릭 유도' || tagStep === '상품태그 추가'}
+          >
             {tagStep === '클릭 유도' && (
               <>
                 <img src={addTagBtn} alt='상품 태그 버튼' />
@@ -93,7 +101,9 @@ export default function PostProductTag({ postedImg, setIsBtnActive }) {
         </ImgBox>
         <p>
           {tagStep === '태그와 버블'
-            ? '다른 상품들도 태그할 수 있어요'
+            ? canSeletedItems.length > 0
+              ? '다른 상품들도 태그할 수 있어요'
+              : ''
             : '원하는 위치에 회원님의 상품을 태그하세요'}
         </p>
       </PostProductTagWrapper>

--- a/src/components/PostUpload/PostProductTag/PostProductTag.jsx
+++ b/src/components/PostUpload/PostProductTag/PostProductTag.jsx
@@ -13,6 +13,7 @@ import {
   userProductsAtom,
 } from '../../../atoms/post';
 import ProductTag from '../ProductTag/ProductTag';
+import { MOUSEBENCHMARK } from '../../../constants/common';
 
 export default function PostProductTag({ postedImg, setIsBtnActive }) {
   //태그추가 단계 : 클릭 유도 / 상품목록 확인 / 태그와 버블 / 상품태그 추가
@@ -28,6 +29,7 @@ export default function PostProductTag({ postedImg, setIsBtnActive }) {
   //선택된 데이터
   const selectedItems = useRecoilValue(selectedProductsAtom);
   const userItems = useRecoilValue(userProductsAtom);
+  const { xLeftBenchmark, xRightBenchmark, yLeftBenchmark, yRightBenchmark } = MOUSEBENCHMARK;
 
   useEffect(() => {
     if (selectedItems.length > 0) {
@@ -43,8 +45,8 @@ export default function PostProductTag({ postedImg, setIsBtnActive }) {
       const x = Math.floor((e.nativeEvent.offsetX / e.currentTarget.offsetWidth) * 100);
       const y = Math.floor((e.nativeEvent.offsetY / e.currentTarget.offsetWidth) * 100);
       setMouseLoc({
-        x: x < 6 ? 6 : x > 94 ? 94 : x,
-        y: y < 5 ? 5 : y > 95 ? 95 : y,
+        x: x < xLeftBenchmark ? xLeftBenchmark : x > xRightBenchmark ? xRightBenchmark : x,
+        y: y < yLeftBenchmark ? yLeftBenchmark : y > yRightBenchmark ? yRightBenchmark : y,
       });
 
       //바텀시트 열고 tagStep 바꾸기

--- a/src/components/PostUpload/PostProductTag/PostProductTagStyle.jsx
+++ b/src/components/PostUpload/PostProductTag/PostProductTagStyle.jsx
@@ -1,4 +1,4 @@
-import styled, { keyframes } from 'styled-components';
+import styled, { css, keyframes } from 'styled-components';
 
 const PostProductTagWrapper = styled.div`
   margin: 0 auto;
@@ -30,6 +30,12 @@ const TagBox = styled.ul`
   top: 0;
   width: 100%;
   height: 100%;
+  ${({ isPointer }) =>
+    isPointer &&
+    css`
+      cursor: pointer;
+    `}
+`;
 
   & > img {
     position: absolute;

--- a/src/components/PostUpload/PostProductTag/PostProductTagStyle.jsx
+++ b/src/components/PostUpload/PostProductTag/PostProductTagStyle.jsx
@@ -30,23 +30,19 @@ const TagBox = styled.ul`
   top: 0;
   width: 100%;
   height: 100%;
-  ${({ isPointer }) =>
-    isPointer &&
-    css`
-      cursor: pointer;
-    `}
+  cursor: ${(p) => p.isPointer && 'pointer'};
 `;
 
-  & > img {
-    position: absolute;
-    width: 20px;
-    border-radius: 50%;
-    box-shadow: 0px 0px 3px rgba(62, 62, 62, 0.3);
-    transform: translate(-50%, -50%);
-    left: 50%;
-    top: 50%;
-    z-index: 1;
-  }
+const GuideTagButton = styled.div.attrs(({ addTagBtn, mouseLoc }) => ({
+  style: {
+    background: `url(${addTagBtn}) no-repeat ${mouseLoc.x}% ${mouseLoc.y}% / 20px`,
+  },
+}))`
+  position: relative;
+  width: 100%;
+  height: 100%;
+  box-shadow: 0px 0px 3px rgba(62, 62, 62, 0.3);
+  z-index: 1;
 `;
 
 const bouncing = keyframes`
@@ -63,18 +59,21 @@ const bouncing = keyframes`
 }
 100% {
   transform: translate(-50%, -50%) scale(2.3);
-  opacity: 0.4;
 }
 `;
 
-const BouncingCircle = styled.div`
+const BouncingCircle = styled.div.attrs(({ mouseLoc }) => ({
+  style: {
+    left: mouseLoc.x + '%',
+    top: mouseLoc.y + '%',
+  },
+}))`
   position: absolute;
   border-radius: 50%;
   width: 20px;
   height: 20px;
   background-color: white;
   animation: ${bouncing} 1s linear alternate infinite;
-  left: 50%;
-  top: 50%;
 `;
-export { PostProductTagWrapper, ImgBox, TagBox, BouncingCircle };
+
+export { PostProductTagWrapper, ImgBox, TagBox, BouncingCircle, GuideTagButton };

--- a/src/components/PostUpload/ProductBubble/ProductBubble.jsx
+++ b/src/components/PostUpload/ProductBubble/ProductBubble.jsx
@@ -1,19 +1,22 @@
 import React from 'react';
 import deleteIcon from '../../../assets/icons/icon-delete.svg';
-import { useRecoilState } from 'recoil';
-import { selectedProductsAtom } from '../../../atoms/post';
+import { useRecoilState, useSetRecoilState } from 'recoil';
+import { mouseLocAtom, selectedProductsAtom } from '../../../atoms/post';
 import { ProductBubbleBox, ProductBubbleWrapper, ProductInfoBox } from './ProductBubbleStyle';
 
-export default function ProductBubble({ data, setTagStep, isBubbleShow = true }) {
+export default function ProductBubble({ data, setTagStep, setIsMouseMove, isBubbleShow = true }) {
   const { itemImage, itemName, price, bubbleLoc } = data;
   const { name } = JSON.parse(itemName);
   const [selectedItems, setSelectedItems] = useRecoilState(selectedProductsAtom);
+  const setMouseLoc = useSetRecoilState(mouseLocAtom);
 
   //해당항목 삭제
   const handleDeleteItem = (e) => {
     e.stopPropagation();
     setSelectedItems((items) => items.filter((item) => item.id !== data.id));
     if (selectedItems.length === 1) {
+      setIsMouseMove(false);
+      setMouseLoc({ x: 50, y: 50 });
       setTagStep('클릭 유도');
     }
   };
@@ -28,7 +31,7 @@ export default function ProductBubble({ data, setTagStep, isBubbleShow = true })
               <h3>{name}</h3>
               <p>{price.toLocaleString()}원</p>
             </ProductInfoBox>
-            <button type='button' onClick={handleDeleteItem}>
+            <button type='button' onMouseUp={handleDeleteItem}>
               <img src={deleteIcon} alt='삭제 버튼' />
             </button>
           </ProductBubbleBox>

--- a/src/constants/common.js
+++ b/src/constants/common.js
@@ -24,3 +24,20 @@ export const TOAST = {
   progress: undefined,
   theme: 'colored',
 };
+
+export const MOUSEBENCHMARK = {
+  xLeftBenchmark: 6,
+  xRightBenchmark: 94,
+  yLeftBenchmark: 5,
+  yRightBenchmark: 95,
+};
+
+export const BUBBLEBENCHMARK = {
+  leftBenchmark: 33,
+  rightBenchmark: 67,
+  leftDefaultValue: 6,
+  rightDefaultValue: 51.5,
+  leftWeighting: 1.59,
+  rightWeighting: 1.63,
+  yPositionBenchmark: 28,
+};

--- a/src/hooks/useBubbleLocation.js
+++ b/src/hooks/useBubbleLocation.js
@@ -1,0 +1,40 @@
+import { useEffect } from 'react';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { bubbleLocAtom, mouseLocAtom } from '../atoms/post';
+import { BUBBLEBENCHMARK } from '../constants/common';
+
+export default function useBubbleLocation() {
+  const setBubbleLoc = useSetRecoilState(bubbleLocAtom);
+  const mouseLoc = useRecoilValue(mouseLocAtom);
+  const { x, y } = mouseLoc;
+  const {
+    leftBenchmark,
+    rightBenchmark,
+    leftDefaultValue,
+    rightDefaultValue,
+    leftWeighting,
+    rightWeighting,
+    yPositionBenchmark,
+  } = BUBBLEBENCHMARK;
+
+  useEffect(() => {
+    let edgeLeft = 50;
+    if (x > rightBenchmark) {
+      edgeLeft = rightDefaultValue + (x - rightBenchmark - 0.5) * rightWeighting;
+    } else if (x < leftBenchmark) {
+      edgeLeft = leftDefaultValue + (x - leftDefaultValue) * leftWeighting;
+    }
+    if (y < yPositionBenchmark) {
+      edgeLeft = edgeLeft - 2.5;
+    }
+
+    setBubbleLoc({
+      x: x < leftBenchmark ? leftBenchmark : x > rightBenchmark ? rightBenchmark : x,
+      y: y > yPositionBenchmark ? y - 7 : y + 27,
+      bubbleUp: y >= yPositionBenchmark,
+      edgeLeft: edgeLeft,
+    });
+  }, [mouseLoc]);
+
+  return null;
+}


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
<!--수정/추가한 작업 내용을 설명해 주세요.-->
게시글 등록 시 +버튼을 클릭뿐아니라 드래그해도 상품 태그 가능하도록 수정했다.
<br><br>

## 🔍 상세 작업 내용
<!-- 작업한 상세 내용을 설명해 주세요.-->
 
- 위치 연산을 위한 숫자의 경우 상수로 관리
- 태그말풍선 위치 계산 로직을 useBubbleLocation으로 분리
- 처음 상품을 태그할 때 클릭뿐아니라 드래그로도 태그 가능하도록 수정
- '상품태그 추가' 단계 이후 '상품목록 확인' 단계에서 모달을 그냥 닫을 때 tagStep을 지정해주지않았던 것을 지정하여 문제 해결
- 주석 간소화

<br><br>

## 💬 참고 사항
<!-- 참고할 만한 사항이 있다면 작성해 주세요. -->

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #208 

<br><br>
