### PR TITLE
🐛 fix: 팔로우, 언팔로우시 깜빡임 현상 해결

### DIFF
--- a/src/components/Follow/FollowButton/FollowButton.jsx
+++ b/src/components/Follow/FollowButton/FollowButton.jsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import Button from '../../common/Button/Button/Button';
+import { useMutation, useQueryClient } from 'react-query';
+import { deleteUnFollow, postFollow } from '../../../api/followApi';
+import { useLocation } from 'react-router-dom';
+import Spinner from '../../common/Spinner/Spinner';
+
+export default function FollowButton({ isfollow, accountname }) {
+  const urlPath = useLocation().pathname;
+  const queryClient = useQueryClient();
+
+  // 팔로우 API
+  const postFollowMutation = useMutation(postFollow, {
+    onSuccess: () => {
+      queryClient.invalidateQueries(urlPath.includes('followers') ? 'followers' : 'followings');
+    },
+    onError: () => {
+      console.error('팔로우 실패');
+    },
+  });
+
+  // 언팔로우 API
+  const deleteUnFollowMutation = useMutation(deleteUnFollow, {
+    onSuccess: () => {
+      queryClient.invalidateQueries(urlPath.includes('followers') ? 'followers' : 'followings');
+    },
+    onError: () => {
+      console.error('언팔로우 실패');
+    },
+  });
+
+  const handleClickFollow = (accountname) => {
+    // 팔로우 API 요청
+    postFollowMutation.mutate(accountname);
+  };
+
+  const handleClickUnFollow = (accountname) => {
+    // 언팔로우 API 요청
+    deleteUnFollowMutation.mutate(accountname);
+  };
+
+  return (
+    <>
+      {isfollow ? (
+        <Button variant='white' size='xs' onClick={() => handleClickUnFollow(accountname)}>
+          {deleteUnFollowMutation.isLoading ? <Spinner type='follow' /> : '언팔로우'}
+        </Button>
+      ) : (
+        <Button size='xs' onClick={() => handleClickFollow(accountname)}>
+          {postFollowMutation.isLoading ? <Spinner type='follow' /> : '팔로우'}
+        </Button>
+      )}
+    </>
+  );
+}

--- a/src/components/common/Spinner/Spinner.jsx
+++ b/src/components/common/Spinner/Spinner.jsx
@@ -20,7 +20,7 @@ const rotator = keyframes`
 
 `;
 const StyledSpinner = styled.div`
-  height: ${(p) => (p.type === 'carousel' ? '404px' : '100vh')};
+  height: ${(p) => (p.type === 'carousel' ? '404px' : p.type === 'follow' ? '16px' : '100vh')};
   margin-top: ${(p) => (p.type === 'carousel' ? '-60px' : '0')};
   display: flex;
   align-items: center;
@@ -28,6 +28,7 @@ const StyledSpinner = styled.div`
 
   svg {
     animation: ${rotator} 1s linear infinite;
+    height: ${(p) => (p.type === 'follow' ? '15px' : '45px')};
   }
 
   circle {

--- a/src/components/common/UserSimpleInfo/UserSimpleInfo/UserSimpleInfo.jsx
+++ b/src/components/common/UserSimpleInfo/UserSimpleInfo/UserSimpleInfo.jsx
@@ -8,7 +8,6 @@ import {
   UserNameBox,
   UserName,
   AccountName,
-  DeleteButton,
 } from './UserSimpleStyle';
 import Button from '../../Button/Button/Button';
 import { useState } from 'react';
@@ -20,7 +19,6 @@ export default function UserSimpleInfo({
   isMyProfile,
   type,
   onClick,
-  onClickFollow,
   inputValue,
 }) {
   const [error, setError] = useState(false);
@@ -85,11 +83,11 @@ export default function UserSimpleInfo({
         !isMyProfile && (
           <>
             {profile.isfollow ? (
-              <Button variant='white' size='xs' onClick={() => onClickFollow(profile.accountname)}>
+              <Button variant='white' size='xs' onClick={() => onClick(profile.accountname)}>
                 언팔로우
               </Button>
             ) : (
-              <Button size='xs' onClick={() => onClickFollow(profile.accountname)}>
+              <Button size='xs' onClick={() => onClick(profile.accountname)}>
                 팔로우
               </Button>
             )}

--- a/src/components/common/UserSimpleInfo/UserSimpleInfo/UserSimpleInfo.jsx
+++ b/src/components/common/UserSimpleInfo/UserSimpleInfo/UserSimpleInfo.jsx
@@ -12,6 +12,7 @@ import {
 import Button from '../../Button/Button/Button';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
+import FollowButton from '../../../Follow/FollowButton/FollowButton';
 
 export default function UserSimpleInfo({
   profile,
@@ -81,17 +82,7 @@ export default function UserSimpleInfo({
         </button>
       ) : type === 'follow' ? (
         !isMyProfile && (
-          <>
-            {profile.isfollow ? (
-              <Button variant='white' size='xs' onClick={() => onClick(profile.accountname)}>
-                언팔로우
-              </Button>
-            ) : (
-              <Button size='xs' onClick={() => onClick(profile.accountname)}>
-                팔로우
-              </Button>
-            )}
-          </>
+          <FollowButton isfollow={profile.isfollow} accountname={profile.accountname} />
         )
       ) : type === 'history' ? (
         <button type='button' onClick={onClick}>

--- a/src/pages/ProfilePage/FollowPage/FollowersPage/FollowersPage.jsx
+++ b/src/pages/ProfilePage/FollowPage/FollowersPage/FollowersPage.jsx
@@ -2,10 +2,9 @@ import React from 'react';
 import BasicLayout from '../../../../layout/BasicLayout';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { FollowerWrapper, FollowerList, FollowItem } from './FollowersPageStyle';
-import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from 'react-query';
-import { deleteUnFollow, getFollowers, postFollow } from '../../../../api/followApi';
+import { useInfiniteQuery, useQuery } from 'react-query';
+import { getFollowers } from '../../../../api/followApi';
 import UserSimpleInfo from '../../../../components/common/UserSimpleInfo/UserSimpleInfo/UserSimpleInfo';
-import Spinner from '../../../../components/common/Spinner/Spinner';
 import useObserver from '../../../../hooks/useObserver';
 import { getMyProfile } from '../../../../api/profileApi';
 
@@ -17,7 +16,6 @@ export default function FollowersPage() {
     data: followers,
     fetchNextPage,
     isLoading,
-    isFetching,
     hasNextPage,
   } = useInfiniteQuery(
     'followers',
@@ -37,71 +35,28 @@ export default function FollowersPage() {
 
   const observerRef = useObserver(hasNextPage, fetchNextPage, isLoading);
 
-  const queryClient = useQueryClient();
-
   const { data: myProfileData } = useQuery('myProfile', getMyProfile);
-
-  // 팔로우 API
-  const postFollowMutation = useMutation(postFollow, {
-    onSuccess: () => {
-      queryClient.invalidateQueries('followers');
-    },
-    onError: () => {
-      console.error('팔로우 실패');
-    },
-  });
-
-  // 언팔로우 API
-  const deleteUnFollowMutation = useMutation(deleteUnFollow, {
-    onSuccess: () => {
-      queryClient.invalidateQueries('followers');
-    },
-    onError: () => {
-      console.error('언팔로우 실패');
-    },
-  });
 
   const handleClickBackButton = () => {
     navigate(-1);
   };
 
-  const handleClickFollow = (accountname) => {
-    // 팔로우 API 요청
-    postFollowMutation.mutate(accountname);
-  };
-
-  const handleClickUnFollow = (accountname) => {
-    // 언팔로우 API 요청
-    deleteUnFollowMutation.mutate(accountname);
-  };
-
-  if (isLoading || isFetching) {
-    return <Spinner />;
-  }
-
   return (
     <BasicLayout type='follow' title='팔로워' onClickLeftButton={handleClickBackButton}>
       <FollowerWrapper>
-        {!isLoading && (
-          <>
-            <FollowerList>
-              {followers?.map((follower) => (
-                <FollowItem key={follower._id}>
-                  <UserSimpleInfo
-                    profile={follower}
-                    type='follow'
-                    isLink={true}
-                    isMyProfile={myProfileData.accountname === follower.accountname}
-                    onClick={follower.isfollow ? handleClickUnFollow : handleClickFollow}
-                  />
-                </FollowItem>
-              ))}
-            </FollowerList>
-          </>
-        )}
-        <div ref={observerRef} style={{ minHeight: '1px' }}>
-          {(isLoading || isFetching) && <Spinner />}
-        </div>
+        <FollowerList>
+          {followers?.map((follower) => (
+            <FollowItem key={follower._id}>
+              <UserSimpleInfo
+                profile={follower}
+                type='follow'
+                isLink={true}
+                isMyProfile={myProfileData.accountname === follower.accountname}
+              />
+            </FollowItem>
+          ))}
+        </FollowerList>
+        <div ref={observerRef} style={{ minHeight: '1px' }}></div>
       </FollowerWrapper>
     </BasicLayout>
   );

--- a/src/pages/ProfilePage/FollowPage/FollowersPage/FollowersPage.jsx
+++ b/src/pages/ProfilePage/FollowPage/FollowersPage/FollowersPage.jsx
@@ -92,7 +92,7 @@ export default function FollowersPage() {
                     type='follow'
                     isLink={true}
                     isMyProfile={myProfileData.accountname === follower.accountname}
-                    onClickFollow={follower.isfollow ? handleClickUnFollow : handleClickFollow}
+                    onClick={follower.isfollow ? handleClickUnFollow : handleClickFollow}
                   />
                 </FollowItem>
               ))}

--- a/src/pages/ProfilePage/FollowPage/FollowingsPage/FollowingsPage.jsx
+++ b/src/pages/ProfilePage/FollowPage/FollowingsPage/FollowingsPage.jsx
@@ -2,10 +2,9 @@ import React from 'react';
 import BasicLayout from '../../../../layout/BasicLayout';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { FollowerWrapper, FollowerList, FollowItem } from '../FollowersPage/FollowersPageStyle';
-import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from 'react-query';
-import { deleteUnFollow, getFollowings, postFollow } from '../../../../api/followApi';
+import { useInfiniteQuery, useQuery } from 'react-query';
+import { getFollowings } from '../../../../api/followApi';
 import UserSimpleInfo from '../../../../components/common/UserSimpleInfo/UserSimpleInfo/UserSimpleInfo';
-import Spinner from '../../../../components/common/Spinner/Spinner';
 import useObserver from '../../../../hooks/useObserver';
 import { getMyProfile } from '../../../../api/profileApi';
 
@@ -17,7 +16,6 @@ export default function FollowingsPage() {
     data: followings,
     fetchNextPage,
     isLoading,
-    isFetching,
     hasNextPage,
   } = useInfiniteQuery(
     'followings',
@@ -36,42 +34,10 @@ export default function FollowingsPage() {
   );
   const observerRef = useObserver(hasNextPage, fetchNextPage, isLoading);
 
-  const queryClient = useQueryClient();
-
   const { data: myProfileData } = useQuery('myProfile', getMyProfile);
-
-  // 팔로우 API
-  const postFollowMutation = useMutation(postFollow, {
-    onSuccess: () => {
-      queryClient.invalidateQueries('followings');
-    },
-    onError: () => {
-      console.error('팔로우 실패');
-    },
-  });
-
-  // 언팔로우 API
-  const deleteUnFollowMutation = useMutation(deleteUnFollow, {
-    onSuccess: () => {
-      queryClient.invalidateQueries('followings');
-    },
-    onError: () => {
-      console.error('언팔로우 실패');
-    },
-  });
 
   const handleClickBackButton = () => {
     navigate(-1);
-  };
-
-  const handleClickFollow = (accountname) => {
-    // 팔로우 API 요청
-    postFollowMutation.mutate(accountname);
-  };
-
-  const handleClickUnFollow = (accountname) => {
-    // 언팔로우 API 요청
-    deleteUnFollowMutation.mutate(accountname);
   };
 
   return (
@@ -86,15 +52,12 @@ export default function FollowingsPage() {
                   type='follow'
                   isLink={true}
                   isMyProfile={myProfileData?.accountname === following.accountname}
-                  onClick={following.isfollow ? handleClickUnFollow : handleClickFollow}
                 />
               </FollowItem>
             ))}
           </FollowerList>
         </>
-        <div ref={observerRef} style={{ minHeight: '1px' }}>
-          {(isLoading || isFetching) && <Spinner />}
-        </div>
+        <div ref={observerRef} style={{ minHeight: '1px' }}></div>
       </FollowerWrapper>
     </BasicLayout>
   );

--- a/src/pages/ProfilePage/FollowPage/FollowingsPage/FollowingsPage.jsx
+++ b/src/pages/ProfilePage/FollowPage/FollowingsPage/FollowingsPage.jsx
@@ -86,7 +86,7 @@ export default function FollowingsPage() {
                   type='follow'
                   isLink={true}
                   isMyProfile={myProfileData?.accountname === following.accountname}
-                  onClickFollow={following.isfollow ? handleClickUnFollow : handleClickFollow}
+                  onClick={following.isfollow ? handleClickUnFollow : handleClickFollow}
                 />
               </FollowItem>
             ))}


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
팔로우, 언팔로우를 했을 때 전체 페이지 로딩으로 인한 깜빡임 현상을 해결하였다.

<br><br>

## 🔍 상세 작업 내용
- 페이지에 있던 팔로우, 언팔로우 API 요청 로직을 FollowButton 컴포넌트에 분리하였다.
- 팔로우, 언팔로우 요청이 로딩중일 때 약간의 시간이 걸리는 것을 대비하여 텍스트 대신에 Spinner 컴포넌트를 보여주었다. 이에 따른 Spinner의 스타일 또한 수정하였다.
- UserSimpleInfo 컴포넌트에 onClick과 onClickFollow 두 가지의 props가 불필요하게 사용되고 있어 onClick props로 통일하였다.

<br><br>

## 💬 참고 사항
<!-- 참고할 만한 사항이 있다면 작성해 주세요. -->

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #230 

<br><br>
