### PR TITLE
🐛 fix: 판매 상품 목록을 받아오지 못하는 문제 해결 및 버튼 추가

### DIFF
--- a/src/components/PostUpload/ModalProductItem/ModalProductItemStyle.jsx
+++ b/src/components/PostUpload/ModalProductItem/ModalProductItemStyle.jsx
@@ -6,6 +6,9 @@ export const ModalProductItemWrapper = styled.li`
   justify-content: space-between;
   margin-bottom: 12px;
   text-align: left;
+  &:nth-last-of-type(1) {
+    margin-bottom: 34px;
+  }
 
   img {
     width: 70px;

--- a/src/components/PostUpload/ModalProductList/ModalProductList.jsx
+++ b/src/components/PostUpload/ModalProductList/ModalProductList.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ModalProductItem from '../ModalProductItem/ModalProductItem';
 import Button from '../../common/Button/Button/Button';
-import { Link } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import { canSelectProductSelector } from '../../../atoms/post';
 import { ModalProductListWrapper } from './ModalProductListStyle';
@@ -9,24 +9,34 @@ import { ModalProductListWrapper } from './ModalProductListStyle';
 export default function ModalProductList({ setIsShow, setTagStep, setIsBubbleShow }) {
   const canSelectItems = useRecoilValue(canSelectProductSelector);
 
+  const navigate = useNavigate();
+  const handleClickProductUploadButton = () => {
+    navigate('/product/upload');
+  };
+
   return (
     <ModalProductListWrapper>
       {canSelectItems.length > 0 ? (
-        canSelectItems.map((item) => (
-          <ModalProductItem
-            data={item}
-            key={item.id}
-            setIsShow={setIsShow}
-            setTagStep={setTagStep}
-            setIsBubbleShow={setIsBubbleShow}
-          />
-        ))
+        <>
+          {canSelectItems.map((item) => (
+            <ModalProductItem
+              data={item}
+              key={item.id}
+              setIsShow={setIsShow}
+              setTagStep={setTagStep}
+              setIsBubbleShow={setIsBubbleShow}
+            />
+          ))}
+          <Button size='md' onClick={handleClickProductUploadButton}>
+            상품 등록
+          </Button>
+        </>
       ) : (
         <>
           <h2>회원님이 판매 중인 상품이 없습니다.</h2>
-          <Link to='/product/upload'>
-            <Button size='md'>상품 등록</Button>
-          </Link>
+          <Button size='md' onClick={handleClickProductUploadButton}>
+            상품 등록
+          </Button>
         </>
       )}
     </ModalProductListWrapper>

--- a/src/components/PostUpload/PostProductTag/PostProductTag.jsx
+++ b/src/components/PostUpload/PostProductTag/PostProductTag.jsx
@@ -21,6 +21,9 @@ import {
 import ProductTag from '../ProductTag/ProductTag';
 import useBubbleLocation from '../../../hooks/useBubbleLocation';
 import { MOUSEBENCHMARK } from '../../../constants/common';
+import { useQuery } from 'react-query';
+import { getMyProfile } from '../../../api/profileApi';
+import { getProducts } from '../../../api/productApi';
 
 export default function PostProductTag({ postImg, setIsBtnActive }) {
   //태그추가 단계 : 클릭 유도 / 상품목록 확인 / 태그와 버블 / 상품태그 추가
@@ -30,9 +33,22 @@ export default function PostProductTag({ postImg, setIsBtnActive }) {
   const [isMouseMove, setIsMouseMove] = useState(false);
   const [mouseLoc, setMouseLoc] = useRecoilState(mouseLocAtom);
   const selectedItems = useRecoilValue(selectedProductsAtom);
-  const userItems = useRecoilValue(userProductsAtom);
+  const [userItems, setUserItems] = useRecoilState(userProductsAtom);
   const canSeletedItems = useRecoilValue(canSelectProductSelector);
   const { xLeftBenchmark, xRightBenchmark, yLeftBenchmark, yRightBenchmark } = MOUSEBENCHMARK;
+
+  const { data: myProfileData } = useQuery('myProfile', getMyProfile);
+  // 상품 목록 정보 가져오기
+  const { data: myProductData } = useQuery(
+    ['myProduct', myProfileData],
+    () => getProducts(myProfileData.accountname),
+    {
+      enabled: !!myProfileData,
+      onSuccess(data) {
+        setUserItems(data);
+      },
+    },
+  );
 
   useEffect(() => {
     if (selectedItems.length > 0) {


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
<!--수정/추가한 작업 내용을 설명해 주세요.-->
판매 상품이 있어도 목록을 받아오지 못하는 문제를 해결하고, 판매상품이 있더라도 추가 등록할 수 있는 버튼을 추가했다.

<br><br>

## 🔍 상세 작업 내용
<!-- 작업한 상세 내용을 설명해 주세요.-->
- 이미지 업로드 시 최적화 작업을 하면서 postImgUpload 컴포넌트에서 실수로 빠졌던 상품목록 정보를 가져오는 함수를 보기 좋게 상품목록을 확인할 수 있는 postProductTag 컴포넌트로 이동시켜 이해하기 쉽도록하여, 판매 상품이 있어도 목록을 받아오지 못하는 문제를 해결했다.
-  판매상품이 있더라도 추가 등록할 수 있는 버튼을 추가했다.
<br><br>

## 💬 참고 사항
<!-- 참고할 만한 사항이 있다면 작성해 주세요. -->
- 판매목록이 있을 시에도 상품등록을 유도하는  버튼을 추가한 것은 좋으나 현재 상품등록 후 다시 게시글 추가로 돌아왔을 경우 이전의 사진 데이터를 저장하지 못해 처음부터 게시글을 작성해야하므로 사용자 측면에서 좋지않을 수 있다. (논의 후 -> v2.0.0 에 추가 예정)

<img width="458" alt="스크린샷 2023-07-27 오전 2 06 08" src="https://github.com/FRONTENDSCHOOL5/final-14-BangKKuseok/assets/102240503/c4fe7bd1-1be0-4456-9cd3-1aa1e7e4914b">




<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #247 

<br><br>
