### PR TITLE
🐛 fix: useScroll에서 발생하는 current값을 못찾는 오류 수정

### DIFF
--- a/src/hooks/useScroll.js
+++ b/src/hooks/useScroll.js
@@ -17,9 +17,10 @@ export default function useScroll() {
   }, 500);
 
   useEffect(() => {
-    reference.current.addEventListener('scroll', handleSetScrollY);
+    const referenceValue = reference.current;
+    referenceValue.addEventListener('scroll', handleSetScrollY);
     return () => {
-      reference.current?.removeEventListener('scroll', handleSetScrollY);
+      referenceValue.removeEventListener('scroll', handleSetScrollY);
     };
   });
 


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
<!--수정/추가한 작업 내용을 설명해 주세요.-->
useScroll에서 발생하는 current값을 못찾는 오류를 수정했다.

<br><br>

## 🔍 상세 작업 내용
<!-- 작업한 상세 내용을 설명해 주세요.-->
클린업함수의 실행 타이밍에 따른 문제로 공식문서에서 같은 문제의 예제코드를 발견하여 확인 후 수정했다.

<br><br>

## 💬 참고 사항
<!-- 참고할 만한 사항이 있다면 작성해 주세요. -->
https://toothsome-debt-b2b.notion.site/useScroll-Effect-Cleanup-Timing-f5c5d0f6948a42e7bd24e46c97545832?pvs=4

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #254 

<br><br>
