### PR TITLE
♻️ refactor: useScroll와 top버튼 사용 위치 옮기기

### DIFF
--- a/src/components/common/Button/TopButton/TopButton.jsx
+++ b/src/components/common/Button/TopButton/TopButton.jsx
@@ -3,7 +3,6 @@ import topBtn from '../../../../assets/images/top-btn.png';
 import debounce from '../../../../utils/debounce';
 import { useLocation } from 'react-router-dom';
 import styled from 'styled-components';
-const regex = new RegExp(/profile\//);
 
 const StyledTopButton = styled.button`
   position: fixed;
@@ -17,29 +16,24 @@ const StyledTopButton = styled.button`
 `;
 
 export default function TopButton({ reference }) {
-  const { pathname } = useLocation();
   const [isShow, setIsShow] = useState(false);
 
   const handleDetectScrollY = debounce(() => {
-    if (
-      pathname === '/home' ||
-      pathname === '/feed' ||
-      pathname === '/profile' ||
-      regex.test(pathname)
-    ) {
-      if (reference.current.scrollTop > 0) {
-        setIsShow(true);
-      } else {
-        setIsShow(false);
-      }
+    if (reference.current.scrollTop > 0) {
+      setIsShow(true);
+    } else {
+      setIsShow(false);
     }
   }, 100);
 
   useEffect(() => {
-    reference.current.addEventListener('scroll', handleDetectScrollY);
-    return () => {
-      reference.current?.removeEventListener('scroll', handleDetectScrollY);
-    };
+    const referenceValue = reference.current;
+    if (referenceValue) {
+      referenceValue.addEventListener('scroll', handleDetectScrollY);
+      return () => {
+        referenceValue.removeEventListener('scroll', handleDetectScrollY);
+      };
+    }
   });
 
   const handleClickTopButton = () => {
@@ -47,10 +41,8 @@ export default function TopButton({ reference }) {
   };
 
   return (
-    <>
-      <StyledTopButton type='button' onClick={handleClickTopButton} isShow={isShow}>
-        <img src={topBtn} alt='상단 이동 버튼' />
-      </StyledTopButton>
-    </>
+    <StyledTopButton type='button' onClick={handleClickTopButton} isShow={isShow}>
+      <img src={topBtn} alt='상단 이동 버튼' />
+    </StyledTopButton>
   );
 }

--- a/src/hooks/useScroll.js
+++ b/src/hooks/useScroll.js
@@ -3,7 +3,6 @@ import { useLocation } from 'react-router-dom';
 import { useRecoilState } from 'recoil';
 import { scrollMemoryAtom } from '../atoms/scroll';
 import debounce from '../utils/debounce';
-const regex = new RegExp(/profile\//);
 
 export default function useScroll() {
   const reference = useRef();
@@ -11,24 +10,22 @@ export default function useScroll() {
   const [scrollMemory, setScrollMemory] = useRecoilState(scrollMemoryAtom);
 
   const handleSetScrollY = debounce(() => {
-    if (pathname === '/feed' || pathname === '/profile' || regex.test(pathname)) {
-      setScrollMemory({ ...scrollMemory, [pathname]: reference.current.scrollTop });
-    }
+    setScrollMemory({ ...scrollMemory, [pathname]: reference.current.scrollTop });
   }, 500);
 
   useEffect(() => {
     const referenceValue = reference.current;
-    referenceValue.addEventListener('scroll', handleSetScrollY);
-    return () => {
-      referenceValue.removeEventListener('scroll', handleSetScrollY);
-    };
+    if (referenceValue) {
+      referenceValue.addEventListener('scroll', handleSetScrollY);
+      return () => {
+        referenceValue.removeEventListener('scroll', handleSetScrollY);
+      };
+    }
   });
 
   useEffect(() => {
-    if (pathname === '/feed' || pathname === '/profile' || regex.test(pathname)) {
+    if (reference.current) {
       reference.current.scrollTo(0, scrollMemory[pathname]);
-    } else {
-      reference.current.scrollTo(0, 0);
     }
   }, []);
 

--- a/src/layout/BasicLayout.jsx
+++ b/src/layout/BasicLayout.jsx
@@ -1,11 +1,8 @@
-import React from 'react';
+import React, { forwardRef } from 'react';
 import Header from '../components/common/Header/Header';
 import Navbar from '../components/common/Navbar/Navbar';
-
 import styled from 'styled-components';
 import Toast from '../components/common/Toast/Toast';
-import useScroll from '../hooks/useScroll';
-import TopButton from '../components/common/Button/TopButton/TopButton';
 
 const LayoutWrapper = styled.div`
   width: clamp(390px, 100%, 720px);
@@ -28,19 +25,17 @@ const LayoutMain = styled.div`
   }
 `;
 
-export default function BasicLayout({ children, isNonNav = false, ...props }) {
-  const wrapperRef = useScroll();
+const BasicLayout = forwardRef(({ children, isNonNav = false, ...props }, ref) => {
   return (
-    <>
-      <LayoutWrapper>
-        <LayoutMain isNonNav={isNonNav} ref={wrapperRef}>
-          <Header {...props} />
-          {children}
-          <Toast />
-          <TopButton reference={wrapperRef} />
-        </LayoutMain>
-        {isNonNav ? null : <Navbar />}
-      </LayoutWrapper>
-    </>
+    <LayoutWrapper>
+      <LayoutMain isNonNav={isNonNav} ref={ref}>
+        <Header {...props} />
+        {children}
+        <Toast />
+      </LayoutMain>
+      {isNonNav ? null : <Navbar />}
+    </LayoutWrapper>
   );
-}
+});
+
+export default BasicLayout;

--- a/src/pages/FeedPage/FeedPage.jsx
+++ b/src/pages/FeedPage/FeedPage.jsx
@@ -13,8 +13,11 @@ import ListModal from '../../components/common/BottomSheet/ListModal';
 import Confirm from '../../components/common/Confirm/Confirm';
 import Search from '../SearchPage/SearchPage';
 import useObserver from '../../hooks/useObserver';
+import useScroll from '../../hooks/useScroll';
+import TopButton from '../../components/common/Button/TopButton/TopButton';
 
 export default function FeedPage() {
+  const wrapperRef = useScroll();
   const [isShow, setIsShow] = useState(false);
   const [isShowConfirm, setIsShowConfirm] = useState(false);
   const [selectedPostId, setSelectedPostId] = useState();
@@ -113,7 +116,7 @@ export default function FeedPage() {
       {isClickSearchButton ? (
         <Search onClickLeftButton={handleClickLeftButton} />
       ) : (
-        <BasicLayout type='feed' onClickRightButton={handleClickRightButton}>
+        <BasicLayout type='feed' onClickRightButton={handleClickRightButton} ref={wrapperRef}>
           <FeedPageWrapper>
             <PostList
               selectedTab='list'
@@ -123,11 +126,16 @@ export default function FeedPage() {
             />
           </FeedPageWrapper>
           <div ref={observerRef} style={{ minHeight: '1px' }}></div>
+          <TopButton reference={wrapperRef} />
+
+          {/* -- BottomSheet */}
           {isShow && (
             <BottomSheet isShow={isShow} onClick={handleClickModalOpen}>
               <ListModal type='userPost' onClick={handleClickListItem} />
             </BottomSheet>
           )}
+
+          {/* -- Confirm */}
           {isShowConfirm && (
             <Confirm
               type='report'

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -11,6 +11,8 @@ import Gallery from '../../components/common/Gallery/Gallery';
 import { filterPosts } from '../../utils/filterPosts';
 import Spinner from '../../components/common/Spinner/Spinner';
 import { topLikedPosts as topLikedMockPosts } from '../../mock/mockData';
+import useScroll from '../../hooks/useScroll';
+import TopButton from '../../components/common/Button/TopButton/TopButton';
 
 const Message = styled.p`
   font-weight: 500;
@@ -34,6 +36,8 @@ const PostWrapper = styled.section`
 `;
 
 export default function HomePage() {
+  const wrapperRef = useScroll();
+
   const [isClickSearchButton, setIsClickSearchButton] = useState(false);
   const [filteredAllPosts, setFilteredAllPosts] = useState([]);
   const [filteredPosts, setfilteredPosts] = useState([]);
@@ -135,7 +139,7 @@ export default function HomePage() {
       {isClickSearchButton ? (
         <Search onClickLeftButton={handleClickLeftButton} />
       ) : (
-        <BasicLayout type='home' onClickRightButton={handleClickRightButton}>
+        <BasicLayout type='home' onClickRightButton={handleClickRightButton} ref={wrapperRef}>
           {isRecent ? (
             <Carousel data={topLikedPosts.length > 0 ? topLikedPosts : topLikedMockPosts} />
           ) : (
@@ -151,6 +155,7 @@ export default function HomePage() {
               <Gallery data={filterPosts(isTabClick ? filteredPosts : filteredAllPosts)} />
             </PostWrapper>
           )}
+          <TopButton reference={wrapperRef} />
         </BasicLayout>
       )}
     </>

--- a/src/pages/ProfilePage/ProfilePage/ProfilePage.jsx
+++ b/src/pages/ProfilePage/ProfilePage/ProfilePage.jsx
@@ -20,6 +20,8 @@ import { deleteProduct, getProducts } from '../../../api/productApi';
 import { deletePost, getMyPost, reportPost } from '../../../api/postApi';
 import { TOAST } from '../../../constants/common';
 import { MYPOSTLIMIT } from '../../../constants/pagenation';
+import TopButton from '../../../components/common/Button/TopButton/TopButton';
+import useScroll from '../../../hooks/useScroll';
 
 const ProfilePageWrapper = styled.main``;
 
@@ -32,6 +34,7 @@ const Message = styled.p`
 `;
 
 export default function ProfilePage() {
+  const wrapperRef = useScroll();
   const navigate = useNavigate();
   const { accountname: accountnameByParams } = useParams();
 
@@ -229,6 +232,7 @@ export default function ProfilePage() {
       type={'profile'}
       onClickLeftButton={() => navigate(-1)}
       onClickRightButton={handleClickMoreProfileButton}
+      ref={wrapperRef}
     >
       {!isProfileLoading && !isMyProfileLoading && !isMyPostLoading && !isProductLoading && (
         <ProfilePageWrapper>
@@ -255,6 +259,7 @@ export default function ProfilePage() {
               <Message>작성된 게시물이 없습니다.</Message>
             )}
           </>
+          <TopButton reference={wrapperRef} />
 
           {/* -- BottomSheet */}
           <BottomSheet isShow={isShowMoreProfile || isShowMorePost} onClick={handleClickCloseModal}>


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
<!--수정/추가한 작업 내용을 설명해 주세요.-->
useScroll와 top버튼 사용 위치를 basiclayout에서 해당 기능이 사용되는 페이지로 옮긴다.
<br><br>

## 🔍 상세 작업 내용
<!-- 작업한 상세 내용을 설명해 주세요.-->
- useScroll와 top버튼 사용 위치를 basiclayout에서 해당 기능이 사용되는 홈, 피드, 프로필 페이지로 옮겼다.
- basiclayout을 forwardRef로 감싸서 ref값을 부모인 페이지에 가져왔다.
- 따라서 basiclayout이 사용되는 모든페이지에서 location을 탐색하고 scoll을 감지할 필요가 없어졌고 useScroll과 topButton 코드도 짧아졌다. 
- 게시글 등록 페이지에서도 탑버튼이 보였던 것을 해결할 수 있었다 

<br><br>

## 💬 참고 사항
<!-- 참고할 만한 사항이 있다면 작성해 주세요. -->

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #257 

<br><br>
