### PR TITLE
🐛 fix: reference.current를 찾지못하는 오류 해결

### DIFF
--- a/src/hooks/useScroll.js
+++ b/src/hooks/useScroll.js
@@ -10,7 +10,10 @@ export default function useScroll() {
   const [scrollMemory, setScrollMemory] = useRecoilState(scrollMemoryAtom);
 
   const handleSetScrollY = debounce(() => {
-    setScrollMemory({ ...scrollMemory, [pathname]: reference.current.scrollTop });
+    setScrollMemory({
+      ...scrollMemory,
+      [pathname]: reference.current ? reference.current.scrollTop : undefined,
+    });
   }, 500);
 
   useEffect(() => {


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
<!--수정/추가한 작업 내용을 설명해 주세요.-->
debounce로 인해 reference를 찾지못하는 오류를 해결했다.
<br><br>

## 🔍 상세 작업 내용
<!-- 작업한 상세 내용을 설명해 주세요.-->
- 무작위로 게시글 상세페이지로 넘어갔을 때 reference값을 찾지 못하는 오류가 발생하였으나, debounce로 인해 스크롤하고 0.5초 뒤 스크롤 위치값을 저장하므로 스크롤을 하고 0.5초 이내로 useScroll이 없는 페이지로 넘어갈 경우 reference값을 찾지 못하는 것을 발견했다.
- 따라서 값의 유무에 따라 삼항연산자를 사용하여 오류를 해결했다. 
<br><br>

## 💬 참고 사항
<!-- 참고할 만한 사항이 있다면 작성해 주세요. -->

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #267 

<br><br>
