### PR TITLE
♻️ refactor: react-query 로직 최적화

### DIFF
--- a/src/api/followApi.js
+++ b/src/api/followApi.js
@@ -1,9 +1,10 @@
+import { FOLLOWLIMIT } from '../constants/pagenation';
 import { accessInstance } from './axiosInstance';
 
 export const getFollowers = async ({ accountname, skip }) => {
   try {
     const response = await accessInstance.get(
-      `/profile/${accountname}/follower/?limit=10&skip=${skip}`,
+      `/profile/${accountname}/follower/?limit=${FOLLOWLIMIT}&skip=${skip}`,
     );
     return {
       data: response.data,
@@ -17,7 +18,7 @@ export const getFollowers = async ({ accountname, skip }) => {
 export const getFollowings = async ({ accountname, skip }) => {
   try {
     const response = await accessInstance.get(
-      `/profile/${accountname}/following/?limit=10&skip=${skip}`,
+      `/profile/${accountname}/following/?limit=${FOLLOWLIMIT}&skip=${skip}`,
     );
 
     return {

--- a/src/constants/pagenation.js
+++ b/src/constants/pagenation.js
@@ -1,3 +1,4 @@
 export const MYPOSTLIMIT = 5;
 export const FEEDPOSTLIMIT = 10;
 export const ALLPOSTLIMIT = 100;
+export const FOLLOWLIMIT = 10;

--- a/src/hooks/useInfiniteDataQuery.js
+++ b/src/hooks/useInfiniteDataQuery.js
@@ -1,0 +1,26 @@
+import { useInfiniteQuery } from 'react-query';
+
+export default function useInfiniteDataQuery(queryKey, queryFn, config) {
+  let accountname;
+
+  if (typeof queryKey === 'object') {
+    accountname = queryKey[1]?.accountname || queryKey[1];
+  }
+
+  const { data, fetchNextPage, isLoading, isFetching, hasNextPage } = useInfiniteQuery(
+    queryKey,
+    ({ pageParam = { skip: 0 } }) => {
+      const queryParam = { accountname: accountname, skip: pageParam.skip };
+      return queryFn(queryParam);
+    },
+    {
+      getNextPageParam: (lastPage, allPages) => {
+        const nextPage = allPages.length > 0 ? allPages.length * config.limit : 0;
+        return lastPage.data.length < config.limit ? undefined : { skip: nextPage };
+      },
+      ...config,
+    },
+  );
+
+  return { data, fetchNextPage, isLoading, isFetching, hasNextPage };
+}

--- a/src/hooks/useReportMutation.js
+++ b/src/hooks/useReportMutation.js
@@ -1,0 +1,16 @@
+import { useMutation } from 'react-query';
+import { toast } from 'react-toastify';
+import { TOAST } from '../constants/common';
+
+export default function useReportMutation(queryFn) {
+  const reportMutation = useMutation(queryFn, {
+    onSuccess() {
+      toast('🚨 신고가 완료되었습니다. 신속하게 처리하겠습니다.', TOAST);
+    },
+    onError(error) {
+      console.log(error);
+    },
+  });
+
+  return reportMutation;
+}

--- a/src/pages/FeedPage/FeedPage.jsx
+++ b/src/pages/FeedPage/FeedPage.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import BasicLayout from '../../layout/BasicLayout';
 import PostList from '../../components/Profile/PostList/PostList';
-import { useInfiniteQuery, useMutation } from 'react-query';
 import { getFeedPost } from '../../api/feedApi';
 import Spinner from '../../components/common/Spinner/Spinner';
 import { FeedPageWrapper, NoneFeedWrapper } from './FeedPageStyle';
@@ -15,7 +14,9 @@ import Search from '../SearchPage/SearchPage';
 import useObserver from '../../hooks/useObserver';
 import useScroll from '../../hooks/useScroll';
 import TopButton from '../../components/common/Button/TopButton/TopButton';
+import useReportMutation from '../../hooks/useReportMutation';
 import { FEEDPOSTLIMIT } from '../../constants/pagenation';
+import useInfiniteDataQuery from '../../hooks/useInfiniteDataQuery';
 
 export default function FeedPage() {
   const wrapperRef = useScroll();
@@ -41,33 +42,19 @@ export default function FeedPage() {
     isLoading,
     isFetching,
     hasNextPage,
-  } = useInfiniteQuery(
-    'feedPostData',
-    ({ pageParam = { skip: 0 } }) => getFeedPost({ skip: pageParam.skip }),
-    {
-      getNextPageParam: (lastPage, allPages) => {
-        const nextPage = allPages.length > 0 ? allPages.length * FEEDPOSTLIMIT : 0;
-        return lastPage.data.length < FEEDPOSTLIMIT ? undefined : { skip: nextPage };
-      },
-      select: (data) => {
-        return {
-          pages: data.pages.flatMap((page) => page.data),
-        };
-      },
+  } = useInfiniteDataQuery('feedPostData', getFeedPost, {
+    limit: FEEDPOSTLIMIT,
+    select: (data) => {
+      return {
+        pages: data.pages.flatMap((page) => page.data),
+      };
     },
-  );
+  });
 
   const observerRef = useObserver(hasNextPage, fetchNextPage, isLoading);
 
   //게시글 신고하기
-  const reportPostMutation = useMutation(reportPost, {
-    onSuccess() {
-      alert(`해당 게시글을 신고했습니다.`);
-    },
-    onError(error) {
-      console.log(error);
-    },
-  });
+  const reportPostMutation = useReportMutation(reportPost);
 
   const handleClickModalOpen = () => {
     setIsShow((prev) => !prev);
@@ -80,13 +67,12 @@ export default function FeedPage() {
   };
 
   //모달안의 신고하기 목록 누르기
-  const handleClickListItem = (e) => {
+  const handleClickListItem = () => {
     setIsShowConfirm(true);
-    console.log(e);
   };
 
   //컨펌창에서 게시글을 신고하기
-  const handleClickConfirm = (e) => {
+  const handleClickConfirm = () => {
     reportPostMutation.mutate(selectedPostId);
     setIsShowConfirm(false);
     setIsShow(false);
@@ -117,7 +103,12 @@ export default function FeedPage() {
       {isClickSearchButton ? (
         <Search onClickLeftButton={handleClickLeftButton} />
       ) : (
-        <BasicLayout type='feed' title='게시글' onClickRightButton={handleClickRightButton} ref={wrapperRef}>
+        <BasicLayout
+          type='feed'
+          title='게시글'
+          onClickRightButton={handleClickRightButton}
+          ref={wrapperRef}
+        >
           <FeedPageWrapper>
             <PostList
               selectedTab='list'

--- a/src/pages/HomePage/HomePage.jsx
+++ b/src/pages/HomePage/HomePage.jsx
@@ -1,10 +1,9 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import Carousel from '../../components/common/Carousel/Carousel';
 import SpaceTabs from '../../components/common/Tabs/SpaceTabs';
 import BasicLayout from '../../layout/BasicLayout';
 import { useState } from 'react';
 import Search from '../SearchPage/SearchPage';
-import { useInfiniteQuery } from 'react-query';
 import { getAllPost } from '../../api/homeApi';
 import styled from 'styled-components';
 import Gallery from '../../components/common/Gallery/Gallery';
@@ -14,6 +13,7 @@ import { topLikedPosts as topLikedMockPosts } from '../../mock/mockData';
 import useScroll from '../../hooks/useScroll';
 import TopButton from '../../components/common/Button/TopButton/TopButton';
 import { ALLPOSTLIMIT } from '../../constants/pagenation';
+import useInfiniteDataQuery from '../../hooks/useInfiniteDataQuery';
 
 const Message = styled.p`
   font-weight: 500;
@@ -57,24 +57,17 @@ export default function HomePage() {
     isLoading: homeIsLoading,
     fetchNextPage: homeFetchNextPage,
     hasNextPage,
-  } = useInfiniteQuery(
-    'homePostData',
-    ({ pageParam = { skip: 0 } }) => getAllPost({ skip: pageParam.skip }),
-    {
-      cacheTime: 0,
-      getNextPageParam: (lastPage, allPages) => {
-        const nextPage = allPages.length > 0 ? allPages.length * ALLPOSTLIMIT : 0;
-        return lastPage.data.length < ALLPOSTLIMIT ? undefined : { skip: nextPage };
-      },
-      onSuccess: (newData) => {
-        const pageParam = newData.pageParams.length - 1;
-        const allFiltered = newData.pages[pageParam].data.filter((post) =>
-          post.content?.includes('"space"'),
-        );
-        setFilteredAllPosts((prevData) => [...prevData, ...allFiltered]);
-      },
+  } = useInfiniteDataQuery('homePostData', getAllPost, {
+    cacheTime: 0,
+    limit: ALLPOSTLIMIT,
+    onSuccess: (newData) => {
+      const pageParam = newData.pageParams.length - 1;
+      const allFiltered = newData.pages[pageParam].data.filter((post) =>
+        post.content?.includes('"space"'),
+      );
+      setFilteredAllPosts((prevData) => [...prevData, ...allFiltered]);
     },
-  );
+  });
 
   useEffect(() => {
     setfilteredPosts(homePostData);

--- a/src/pages/PostPage/PostPage/PostPage.jsx
+++ b/src/pages/PostPage/PostPage/PostPage.jsx
@@ -16,6 +16,7 @@ import { deleteComment, getComments, reportComment } from '../../../api/commentA
 import CommentSection from '../../../components/PostDetail/CommentSection/CommentSection';
 import { TOAST } from '../../../constants/common';
 import { myProfileDataAtom } from '../../../atoms/myProfile';
+import useReportMutation from '../../../hooks/useReportMutation';
 
 export default function PostPage() {
   const { postId } = useParams();
@@ -79,16 +80,6 @@ export default function PostPage() {
     },
   });
 
-  //게시글 신고하기
-  const reportPostMutation = useMutation(reportPost, {
-    onSuccess() {
-      toast('🚨 신고가 완료되었습니다. 신속하게 처리하겠습니다.', TOAST);
-    },
-    onError(error) {
-      console.log(error);
-    },
-  });
-
   //댓글 삭제하기
   const queryClient = useQueryClient();
   const deleteCommentMutation = useMutation(deleteComment, {
@@ -101,15 +92,11 @@ export default function PostPage() {
     },
   });
 
+  //게시글 신고하기
+  const reportPostMutation = useReportMutation(reportPost);
+
   //댓글 신고하기
-  const reportCommentMutation = useMutation(reportComment, {
-    onSuccess() {
-      toast('🚨 신고가 완료되었습니다. 신속하게 처리하겠습니다.', TOAST);
-    },
-    onError(error) {
-      console.log(error);
-    },
-  });
+  const reportCommentMutation = useReportMutation(reportComment);
 
   const handleClickModalOpen = () => {
     setIsShow((prev) => !prev);

--- a/src/pages/ProfilePage/FollowPage/FollowersPage/FollowersPage.jsx
+++ b/src/pages/ProfilePage/FollowPage/FollowersPage/FollowersPage.jsx
@@ -2,12 +2,13 @@ import React from 'react';
 import BasicLayout from '../../../../layout/BasicLayout';
 import { useLocation } from 'react-router-dom';
 import { FollowerWrapper, FollowerList, FollowItem } from './FollowersPageStyle';
-import { useInfiniteQuery } from 'react-query';
 import { getFollowers } from '../../../../api/followApi';
 import UserSimpleInfo from '../../../../components/common/UserSimpleInfo/UserSimpleInfo/UserSimpleInfo';
 import useObserver from '../../../../hooks/useObserver';
+import useInfiniteDataQuery from '../../../../hooks/useInfiniteDataQuery';
 import { useRecoilValue } from 'recoil';
 import { myProfileDataAtom } from '../../../../atoms/myProfile';
+import { FOLLOWLIMIT } from '../../../../constants/pagenation';
 
 export default function FollowersPage() {
   const accountname = useLocation().state.accountname;
@@ -19,21 +20,13 @@ export default function FollowersPage() {
     fetchNextPage,
     isLoading,
     hasNextPage,
-  } = useInfiniteQuery(
-    'followers',
-    ({ pageParam = { skip: 0 } }) =>
-      getFollowers({ accountname: accountname, skip: pageParam.skip }),
-    {
-      getNextPageParam: (lastPage, allPages) => {
-        const nextPage = allPages.length > 0 ? allPages.length * 10 : 0;
-        return lastPage.data.length < 10 ? undefined : { skip: nextPage };
-      },
-      select: (data) => {
-        return data.pages.flatMap((page) => page.data);
-      },
-      enabled: !!accountname,
+  } = useInfiniteDataQuery(['followers', accountname], getFollowers, {
+    limit: FOLLOWLIMIT,
+    select: (data) => {
+      return data.pages.flatMap((page) => page.data);
     },
-  );
+    enabled: !!accountname,
+  });
 
   const observerRef = useObserver(hasNextPage, fetchNextPage, isLoading);
 

--- a/src/pages/ProfilePage/FollowPage/FollowersPage/FollowersPage.jsx
+++ b/src/pages/ProfilePage/FollowPage/FollowersPage/FollowersPage.jsx
@@ -37,8 +37,6 @@ export default function FollowersPage() {
 
   const observerRef = useObserver(hasNextPage, fetchNextPage, isLoading);
 
-  const { data: myProfileData } = useQuery('myProfile', getMyProfile);
-
   return (
     <BasicLayout type='follow' title='팔로워'>
       <FollowerWrapper>

--- a/src/pages/ProfilePage/FollowPage/FollowingsPage/FollowingsPage.jsx
+++ b/src/pages/ProfilePage/FollowPage/FollowingsPage/FollowingsPage.jsx
@@ -36,7 +36,6 @@ export default function FollowingsPage() {
   );
   const observerRef = useObserver(hasNextPage, fetchNextPage, isLoading);
 
-  const { data: myProfileData } = useQuery('myProfile', getMyProfile);
 
   return (
     <BasicLayout type='follow' title='팔로잉'>

--- a/src/pages/ProfilePage/FollowPage/FollowingsPage/FollowingsPage.jsx
+++ b/src/pages/ProfilePage/FollowPage/FollowingsPage/FollowingsPage.jsx
@@ -2,12 +2,13 @@ import React from 'react';
 import BasicLayout from '../../../../layout/BasicLayout';
 import { useLocation } from 'react-router-dom';
 import { FollowerWrapper, FollowerList, FollowItem } from '../FollowersPage/FollowersPageStyle';
-import { useInfiniteQuery } from 'react-query';
 import { getFollowings } from '../../../../api/followApi';
 import UserSimpleInfo from '../../../../components/common/UserSimpleInfo/UserSimpleInfo/UserSimpleInfo';
 import useObserver from '../../../../hooks/useObserver';
+import useInfiniteDataQuery from '../../../../hooks/useInfiniteDataQuery';
 import { useRecoilValue } from 'recoil';
 import { myProfileDataAtom } from '../../../../atoms/myProfile';
+import { FOLLOWLIMIT } from '../../../../constants/pagenation';
 
 export default function FollowingsPage() {
   const accountname = useLocation().state.accountname;
@@ -19,23 +20,15 @@ export default function FollowingsPage() {
     fetchNextPage,
     isLoading,
     hasNextPage,
-  } = useInfiniteQuery(
-    'followings',
-    ({ pageParam = { skip: 0 } }) =>
-      getFollowings({ accountname: accountname, skip: pageParam.skip }),
-    {
-      getNextPageParam: (lastPage, allPages) => {
-        const nextPage = allPages.length > 0 ? allPages.length * 10 : 0;
-        return lastPage.data.length < 10 ? undefined : { skip: nextPage };
-      },
-      select: (data) => {
-        return data.pages.flatMap((page) => page.data);
-      },
-      enabled: !!accountname,
+  } = useInfiniteDataQuery(['followings', accountname], getFollowings, {
+    limit: FOLLOWLIMIT,
+    select: (data) => {
+      return data.pages.flatMap((page) => page.data);
     },
-  );
-  const observerRef = useObserver(hasNextPage, fetchNextPage, isLoading);
+    enabled: !!accountname,
+  });
 
+  const observerRef = useObserver(hasNextPage, fetchNextPage, isLoading);
 
   return (
     <BasicLayout type='follow' title='팔로잉'>

--- a/src/pages/ProfilePage/ProfilePage/ProfilePage.jsx
+++ b/src/pages/ProfilePage/ProfilePage/ProfilePage.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { toast } from 'react-toastify';
 import styled from 'styled-components';
 import BasicLayout from '../../../layout/BasicLayout';
@@ -14,7 +14,7 @@ import Confirm from '../../../components/common/Confirm/Confirm';
 import Spinner from '../../../components/common/Spinner/Spinner';
 import useObserver from '../../../hooks/useObserver';
 import { useNavigate, useParams } from 'react-router-dom';
-import { useInfiniteQuery, useMutation, useQuery, useQueryClient } from 'react-query';
+import { useMutation, useQuery, useQueryClient } from 'react-query';
 import { getMyProfile, getProfile } from '../../../api/profileApi';
 import { deleteProduct, getProducts } from '../../../api/productApi';
 import { deletePost, getMyPost, reportPost } from '../../../api/postApi';
@@ -24,6 +24,8 @@ import TopButton from '../../../components/common/Button/TopButton/TopButton';
 import useScroll from '../../../hooks/useScroll';
 import { useRecoilValue } from 'recoil';
 import { myProfileDataAtom } from '../../../atoms/myProfile';
+import useReportMutation from '../../../hooks/useReportMutation';
+import useInfiniteDataQuery from '../../../hooks/useInfiniteDataQuery';
 
 const ProfilePageWrapper = styled.main``;
 
@@ -69,21 +71,13 @@ export default function ProfilePage() {
     fetchNextPage: fetchPostNextPage,
     isLoading: isMyPostLoading,
     hasNextPage: hasPostNextPage,
-  } = useInfiniteQuery(
-    ['myPost', profileData],
-    ({ pageParam = { skip: 0 } }) =>
-      getMyPost({ accountname: profileData.accountname, skip: pageParam.skip }),
-    {
-      getNextPageParam: (lastPage, allPages) => {
-        const nextPage = allPages.length > 0 ? allPages.length * MYPOSTLIMIT : 0;
-        return lastPage.data.length < MYPOSTLIMIT ? undefined : { skip: nextPage };
-      },
-      select: (data) => {
-        return data.pages.flatMap((page) => page.data);
-      },
-      enabled: !!profileData,
+  } = useInfiniteDataQuery(['myPost', profileData], getMyPost, {
+    limit: MYPOSTLIMIT,
+    select: (data) => {
+      return data.pages.flatMap((page) => page.data);
     },
-  );
+    enabled: !!profileData,
+  });
 
   const observerRef = useObserver(hasPostNextPage, fetchPostNextPage, isMyPostLoading);
 
@@ -119,14 +113,7 @@ export default function ProfilePage() {
   });
 
   //게시글 신고하기
-  const reportPostMutation = useMutation(reportPost, {
-    onSuccess() {
-      toast('🚨 신고가 완료되었습니다. 신속하게 처리하겠습니다.', TOAST);
-    },
-    onError(error) {
-      console.log(error);
-    },
-  });
+  const reportPostMutation = useReportMutation(reportPost);
 
   const handleClickTabButton = (tabId) => {
     setSelectedTab(tabId);


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
react-query를 사용한 reportMutaion, useInfiniteQuery 부분을 커스텀 훅으로 만들어 재사용성을 증가시켰다.

<br><br>

## 🔍 상세 작업 내용
- 팔로우 페이지 limit 숫자를 상수화하였습니다.
- 이전 PR에서 develop에 병합 충돌 해결시 추가되었던 오류 코드를 삭제하였습니다.
- useInfiniteQuery 부분을 useInfiniteDataQuery 커스텀 훅으로 교체하였습니다.
- reportMutation이 공통으로 사용되어 useReportMutation 커스텀 훅으로 교체하였습니다.

<br><br>

## 💬 참고 사항
- 현재 api 요청 쿼리에 accountname이 사용되는 경우, queryKey 값에 포함된 accountname을 활용하였기 때문에 queryKey에 필수적으로 accoutname을 포함시켜야 합니다.
- 🔗 [react query 최적화 기록](https://www.notion.so/react-query-3ed749ef3e1044649de6e984bfdb37fe?pvs=4)

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #261 

<br><br>
