### PR TITLE
🐛 fix: 게시글 삭제시 오류 해결하기 위해 navigate('/') 추가

### DIFF
--- a/src/pages/PostPage/PostPage/PostPage.jsx
+++ b/src/pages/PostPage/PostPage/PostPage.jsx
@@ -152,6 +152,7 @@ export default function PostPage() {
       //삭제하기
       if (confirmType.type === 'delete') {
         deletePostMutation.mutate(postId);
+        navigate('/');
       } else {
         //신고하기
         reportPostMutation.mutate(postId);


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
<!--수정/추가한 작업 내용을 설명해 주세요.-->
게시글 삭제시 오류 해결하기 위해 navigate('/') 추가
<br><br>

## 🔍 상세 작업 내용
<!-- 작업한 상세 내용을 설명해 주세요.-->
게시글을 삭제하면 navigate(-1)이 기본이라 수정 후 삭제하거나 등록 후 바로 삭제하면 이미 삭제된 게시글의 수정페이지로 이동하는 등의 문제가 생겨 게시글을 삭제하면 무조건 home으로 가게 해주었다.
<br><br>

## 💬 참고 사항
<!-- 참고할 만한 사항이 있다면 작성해 주세요. -->

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #280

<br><br>
