### PR TITLE
♻️ refactor: 이메일, 비밀번호 유효성 검사 및 입력 값 커스텀 훅으로 관리

### DIFF
--- a/src/components/LoginSignUp/LoginSignUp/LoginSignUp.jsx
+++ b/src/components/LoginSignUp/LoginSignUp/LoginSignUp.jsx
@@ -3,118 +3,38 @@ import { Link } from 'react-router-dom';
 import { LoginSignUpWrapper, LoginSignUpLogo, BottomBox, LinkWrapper } from './LoginSignUpStyle';
 import Input from '../../common/Input/Input';
 import Button from '../../common/Button/Button/Button';
+import useUserForm from '../../../hooks/useUserForm';
 
 export default function LoginSignUp({ logo, type, setPreData, preData, message, onClickNextLink }) {
   // 이메일, 비밀번호 값을 받아옴
-  const [emailValue, setEmailValue] = useState(preData.email ?? '');
-  const [passwordValue, setPasswordValue] = useState(preData.password ?? '');
-
-  // 에러메시지 설정
-  const [emailError, setEmailError] = useState('');
-  const [passwordError, setPasswordError] = useState('');
-
-  // 이메일이 유효하지 않으면 true
-  const [isEmailInValid, setIsEmailInValid] = useState(true);
-  // 비밀번호가 유효하지 않으면 true
-  const [isPasswordInValid, setIsPasswordInValid] = useState(true);
+  const [formData, isValidFormData, errorMessage, handleSetErrorMessage, handleChange] =
+    useUserForm(preData);
 
   // 버튼 활성화를 위해 만듦.
-  const [btnDisabled, setBtnDisabled] = useState(true);
+  const [isBtnDisabled, setIsBtnDisalbed] = useState(true);
 
-  // 회원가입에서 이메일 중복 유효성 체크 실패시 email입력칸 아래에 에러메시지
-  // 로그인에서 로그인 실패시 password입력칸 아래에 에러메시지
-  useEffect(() => {
-    if (type === 'signup') {
-      setEmailError(message);
-      setIsEmailInValid(true);
-    } else if (type === 'login') {
-      setPasswordError(message);
-      setIsPasswordInValid(true);
-    }
-    setBtnDisabled(true);
-  }, [message]);
-
-  // 이메일 입력값 받아오기
-  const handleEmailChange = (e) => {
-    const value = e.target.value;
-    setEmailError('');
-    setEmailValue(value);
-  };
-
-  // 비밀번호 입력값 받아오기
-  const handlePasswordChange = (e) => {
-    const value = e.target.value;
-    setPasswordError('');
-    setPasswordValue(value);
-  };
-
-  // 이메일 유효성 검사 후 에러메시지 갱신
-  const handleValidateEmail = (e) => {
-    if (
-      !/^[A-Za-z0-9._-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/i.test(emailValue) &&
-      emailValue.length > 0
-    ) {
-      setBtnDisabled(true);
-      setIsEmailInValid(true);
-      setEmailError('잘못된 이메일 형식입니다.');
-    } else if (emailValue.length === 0) {
-      setBtnDisabled(true);
-      setIsEmailInValid(true);
-      setEmailError('이메일을 입력해주세요.');
-    } else {
-      setEmailError('');
-      setIsEmailInValid(false);
-    }
-  };
-
-  // 비밀번호 유효성 검사 후 에러메시지 갱신
-  const handleValidatePassword = () => {
-    if (passwordValue.length === 0) {
-      setBtnDisabled(true);
-      setIsPasswordInValid(true);
-      setPasswordError('비밀번호를 입력해주세요.');
-    } else if (passwordValue.length < 6 && passwordValue.length > 0) {
-      setBtnDisabled(true);
-      setIsPasswordInValid(true);
-      setPasswordError('비밀번호는 6자 이상이어야 합니다.');
-    } else {
-      setPasswordError('');
-      setIsPasswordInValid(false);
-    }
-  };
-
-  useEffect(() => {
-    setPreData({
-      email: emailValue,
-      password: passwordValue,
-    });
-    if (type === 'signup') {
-      if (emailValue.length > 0 || passwordValue.length > 0) {
-        setBtnDisabled(false);
-      }
-    } else if (type === 'login') {
-      if (emailValue.length > 0 && passwordValue.length > 0) {
-        setBtnDisabled(false);
-      } else {
-        setBtnDisabled(true);
-      }
-    }
-  }, [emailValue, passwordValue]);
-
-  // 버튼이 눌리면
   const handleSubmit = (e) => {
     e.preventDefault();
 
-    handleValidateEmail();
-    handleValidatePassword();
+    if (type === 'login') {
+      handleSetErrorMessage();
+    }
 
-    // 이메일, 비밀번호 둘 중 유효하지 않은 값이 있다면 isInValid가 true
-    setBtnDisabled(isEmailInValid || isPasswordInValid);
-
-    if (!btnDisabled) {
+    if (!isBtnDisabled) {
       onClickNextLink();
+      setIsBtnDisalbed(message || isValidFormData.email || isValidFormData.password);
     }
   };
+
+  useEffect(() => {
+    setPreData((prev) => ({ ...prev, email: formData.email, password: formData.password }));
+
+    if (!formData.email || !formData.password) {
+      setIsBtnDisalbed(true);
+    } else {
+      setIsBtnDisalbed(false);
+    }
+  }, [formData, setPreData]);
 
   return (
     <LoginSignUpWrapper>
@@ -124,12 +44,12 @@ export default function LoginSignUp({ logo, type, setPreData, preData, message, 
         inputType='email'
         labelText='이메일'
         placeHolder='이메일을 입력하세요'
-        value={emailValue}
-        warningMsg={emailError}
-        onChange={handleEmailChange}
+        value={formData.email}
+        warningMsg={(type === 'signup' && message) || errorMessage.email}
+        onChange={handleChange}
         // signup일때만 onBlur시에 바로 유효성 검사
-        onBlur={() => type === 'signup' && handleValidateEmail()}
-        isInValid={isEmailInValid}
+        onBlur={() => type === 'signup' && handleSetErrorMessage()}
+        isInValid={isValidFormData.email}
       />
 
       <Input
@@ -137,15 +57,15 @@ export default function LoginSignUp({ logo, type, setPreData, preData, message, 
         inputType='password'
         labelText='비밀번호'
         placeHolder='비밀번호를 입력하세요'
-        value={passwordValue}
-        warningMsg={passwordError}
-        onChange={handlePasswordChange}
+        value={formData.password}
+        warningMsg={(type === 'login' && message) || errorMessage.password}
+        onChange={handleChange}
         // signup일때만 onBlur시에 바로 유효성 검사
-        onBlur={() => type === 'signup' && handleValidatePassword()}
-        isInValid={isPasswordInValid}
+        onBlur={() => type === 'signup' && handleSetErrorMessage()}
+        isInValid={isValidFormData.password}
       />
       <BottomBox>
-        <Button type='submit' size='lg' onClick={handleSubmit} disabled={btnDisabled}>
+        <Button type='submit' size='lg' onClick={handleSubmit} disabled={isBtnDisabled}>
           다음
         </Button>
         <LinkWrapper>

--- a/src/constants/validate.js
+++ b/src/constants/validate.js
@@ -11,4 +11,20 @@ export const REG = {
   link: /^.{1,}$/,
 };
 
+export const USER_WARNING_MSG = {
+  email: {
+    format: '잘못된 이메일 형식입니다.',
+    require: '이메일을 입력해주세요.',
+  },
+  password: {
+    format: '비밀번호는 6자 이상이어야 합니다.',
+    require: '비밀번호를 입력해주세요.',
+  },
+};
+
+export const USER_REG = {
+  email: /^[A-Za-z0-9._-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/i,
+  password: /^.{6,}$/,
+};
+
 export const MAX_PRICE = 999999999;

--- a/src/hooks/useUserForm.js
+++ b/src/hooks/useUserForm.js
@@ -1,0 +1,46 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { USER_REG, USER_WARNING_MSG } from '../constants/validate';
+
+export default function useUserForm(initialData) {
+  // 이메일, 비밀번호 값을 받아옴
+  const [values, setValues] = useState({
+    email: initialData.email ?? '',
+    password: initialData.password ?? '',
+  });
+
+  // 에러 메시지
+  const [errorMessage, setErrorMessage] = useState({
+    email: '',
+    password: '',
+  });
+
+  // 이메일, 비밀번호 유효성 결과 저장
+  const isValidValues = useMemo(
+    () => ({
+      email: USER_REG.email.test(values.email),
+      password: USER_REG.password.test(values.password),
+    }),
+    [values.email, values.password],
+  );
+
+  // 이메일, 비밀번호 입력값 받아오기
+  const handleChange = useCallback((e) => {
+    const { type: name, value } = e.target;
+    setValues((prev) => ({ ...prev, [name]: value }));
+    setErrorMessage({ email: '', password: '' });
+  }, []);
+
+  const handleSetErrorMessage = useCallback(() => {
+    // 입력한 값이 없을 때 || 유효하지 않은 값일 때
+    setErrorMessage({
+      email:
+        (!values.email && USER_WARNING_MSG.email.require) ||
+        (!isValidValues.email && USER_WARNING_MSG.email.format),
+      password:
+        (!values.password && USER_WARNING_MSG.password.require) ||
+        (!isValidValues.password && USER_WARNING_MSG.password.format),
+    });
+  }, [values, isValidValues]);
+
+  return [values, isValidValues, errorMessage, handleSetErrorMessage, handleChange];
+}


### PR DESCRIPTION
- [x] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `✨feat: PR 등록`
- [x] 🧹 불필요한 코드는 제거했나요?
- [x] 💭 이슈는 등록했나요?
- [x] 🏷️ 라벨은 등록했나요?

<br>

## ⚡ PR 한 줄 요약
로그인, 회원가입시 입력하는 이메일, 비밀번호에 대한 유효성 검사와 에러메시지, 입력 값에 대한 로직을 커스텀 훅으로 분리하였습니다.

<br><br>

## 🔍 상세 작업 내용
> 기존 코드 수정 방안

1. isEmailInValid, isPasswordInvalid
- 입력한 값이 유효한 값인지에 따라 `true` or `false`의 값을 가집니다.
- 입력한 값에 의존하고 있기 때문에 따로 상태값으로 관리할 필요가 없습니다.

2. 버튼 활성화, 에러 메시지
- 버튼 활성화와 에러 메시지의 경우 초기값이 존재하고, 이후 이벤트 발생에 따라 값이 지정되므로 상태값으로 관리해야 한다고 생각했습니다.

3. 중복된 함수 로직
- input에 값을 입력하면 `change` 이벤트가 발생하여 입력 값을 상태로 저장해야합니다.
- 이메일과 비밀번호의 경우 동일한 로직으로 동작하고 있기 때문에 이를 커스텀 훅에서 한번에 저장하여 관리할 수 있습니다.
- 기존의 코드와 같이 각각 change 이벤트 핸들러를 사용하게 되면 하나가 변경될 때 다른 하나도 추가적으로 변경시켜줘야하는 번거로움이 발생하기 때문에 코드의 중복을 줄이고, 재사용성 및 유지보수를 용이하게 하도록 커스텀 훅으로 관리할 필요성이 있습니다.

4. 에러 메시지의 갱신 또한 커스텀 훅의 `handleSetErrorMessage()` 함수로 입력 값과 유효성 검사 결과 값에 기반하여 에러 메시지 상태 값을 객체로 관리할 수 있게 변경해주었습니다.

<br><br>

## 💬 참고 사항
<!-- 참고할 만한 사항이 있다면 작성해 주세요. -->
기존 프로젝트 로직과 비교하며 테스트를 진행했지만, 혹시 모를 의도치 않은 동작이 있을 수 있으므로 확인 후에 승인부탁드립니다 !

<br><br>

## 💡 관련 이슈
<!-- 아래 이슈 번호를 작성하면 해당 이슈가 Close 됩니다. -->
<!-- ex) Close #14 -->

- Close #265 

<br><br>
